### PR TITLE
use COPY instead of clone to get repo contents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN [ "/bin/bash", "-c", "cd MultiNest/build/ && cmake .. && make && cd ../../" 
 ENV LD_LIBRARY_PATH=/home/jovyan/MultiNest/lib/:$LD_LIBRARY_PATH
 
 USER $NB_USER
-RUN git clone  --recurse https://github.com/oslocyclotronlab/ompy/
+COPY . ompy
 # REMBEBER TO checkout the BRANCH you want
 RUN cd ompy &&\
     pip install -e .

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,10 @@ RUN [ "/bin/bash", "-c", "cd MultiNest/build/ && cmake .. && make && cd ../../" 
 ENV LD_LIBRARY_PATH=/home/jovyan/MultiNest/lib/:$LD_LIBRARY_PATH
 
 USER $NB_USER
-COPY . ompy
+# Due to some cache issue with Mybinder we ought to use COPY instead
+# of git clone.
+COPY --chown=1000:100 . ompy
 # REMBEBER TO checkout the BRANCH you want
 RUN cd ompy &&\
+    git submodule update --init --recursive &&\
     pip install -e .


### PR DESCRIPTION
ensures that `docker build .` is in sync with the current checkout of the repo

This was the cause of https://github.com/jupyterhub/binder/issues/173

because the docker build cache is based on the lines in the Dockerfile. Changing the repo contents only invalidates the build cache if the contents are added via COPY, not via `git clone`. Since the line is unchanged, it assumes the cached result can be used and pushing to the repo doesn't force a rebuild of the image.

This will also make it easier to build the Dockerfile with a particular branch or fork