### PR TITLE
Fixes #85 by showing always the current git sha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
-ompy/version.py
+ompy/version_setup.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/ompy/__init__.py
+++ b/ompy/__init__.py
@@ -12,37 +12,38 @@ if __OMPY_SETUP__:
 else:
     try:
         from ompy.rebin import *
+        # if importing one of the cython modules fails, it may hint on it
+        # not beeing installed correctly
     except ImportError:
         msg = """Error importing ompy: you should not try to import ompy from
         its source directory; please exit the ompy source tree, and relaunch
         your python interpreter from there."""
         raise ImportError(msg)
-    from .version import git_revision as __git_revision__
-    from .version import version as __version__
-    from .version import full_version as __full_version__
+    from .version import GIT_REVISION as __git_revision__
+    from .version import VERSION as __version__
+    from .version import FULLVERSION as __full_version__
 
-
-# Simply import all functions and classes from all files to make them available
-# at the package level
-from .library import div0, fill_negative
-from .spinfunctions import SpinFunctions
-from .abstractarray import AbstractArray
-from .matrix import Matrix
-from .models import Model, NormalizationParameters, ResultsNormalized
-from .vector import Vector
-from .unfolder import Unfolder
-from .examples import example_raw, list_examples
-from .ensemble import Ensemble
-from .response import Response
-from .gauss_smoothing import *
-from .firstgeneration import FirstGeneration, normalize_rows
-from .extractor import Extractor
-from .action import Action
-from .decomposition import nld_T_product, index
-from .normalizer_nld import (NormalizerNLD, load_levels_discrete,
-                             load_levels_smooth)
-from .normalizer_gsf import NormalizerGSF
-from .normalizer_simultan import NormalizerSimultan
-from .ensembleNormalizer import EnsembleNormalizer
-from .models import NormalizationParameters, ResultsNormalized
-from .introspection import logging, hooks
+    # Simply import all functions and classes from all files to make them
+    # available at the package level
+    from .library import div0, fill_negative
+    from .spinfunctions import SpinFunctions
+    from .abstractarray import AbstractArray
+    from .matrix import Matrix
+    from .models import Model, NormalizationParameters, ResultsNormalized
+    from .vector import Vector
+    from .unfolder import Unfolder
+    from .examples import example_raw, list_examples
+    from .ensemble import Ensemble
+    from .response import Response
+    from .gauss_smoothing import *
+    from .firstgeneration import FirstGeneration, normalize_rows
+    from .extractor import Extractor
+    from .action import Action
+    from .decomposition import nld_T_product, index
+    from .normalizer_nld import (NormalizerNLD, load_levels_discrete,
+                                 load_levels_smooth)
+    from .normalizer_gsf import NormalizerGSF
+    from .normalizer_simultan import NormalizerSimultan
+    from .ensembleNormalizer import EnsembleNormalizer
+    from .models import NormalizationParameters, ResultsNormalized
+    from .introspection import logging, hooks

--- a/ompy/version.py
+++ b/ompy/version.py
@@ -1,0 +1,59 @@
+# version info and git commit at execution time
+# see also setup.py
+import os
+import subprocess
+from .version_setup import version as VERSION
+
+
+# Return the git revision as a string
+def git_version():
+    def _minimal_ext_cmd(cmd):
+        # construct minimal environment
+        env = {}
+        for k in ['SYSTEMROOT', 'PATH', 'HOME']:
+            v = os.environ.get(k)
+            if v is not None:
+                env[k] = v
+        # LANGUAGE is used on win32
+        env['LANGUAGE'] = 'C'
+        env['LANG'] = 'C'
+        env['LC_ALL'] = 'C'
+        out = subprocess.check_output(cmd, stderr=subprocess.STDOUT, env=env)
+        return out
+
+    try:
+        out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
+        GIT_REVISION = out.strip().decode('ascii')
+    except (subprocess.SubprocessError, OSError):
+        GIT_REVISION = "Unknown"
+
+    if not GIT_REVISION:
+        # this shouldn't happen but apparently can (see gh-8512)
+        GIT_REVISION = "Unknown"
+
+    return GIT_REVISION
+
+
+def get_version_info():
+    # Adding the git rev number needs to be done inside write_version_py(),
+    # otherwise the import of ompy.version messes up the build under Python 3.
+    FULLVERSION = VERSION
+    if os.path.exists('.git'):
+        GIT_REVISION = git_version()
+    elif os.path.exists('ompy/version.py'):
+        # must be a source distribution, use existing version file
+        try:
+            from ompy.version import git_revision as GIT_REVISION
+        except ImportError:
+            raise ImportError("Unable to import git_revision. Try removing "
+                              "ompy/version.py and the build directory "
+                              "before building.")
+    else:
+        GIT_REVISION = "Unknown"
+
+    FULLVERSION += '.dev0+' + GIT_REVISION[:7]
+
+    return FULLVERSION, GIT_REVISION
+
+
+FULLVERSION, GIT_REVISION = get_version_info()

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 
 # Return the git revision as a string
+# See also ompy/version.py
 def git_version():
     def _minimal_ext_cmd(cmd):
         # construct minimal environment
@@ -88,10 +89,10 @@ def get_version_info():
     return FULLVERSION, GIT_REVISION
 
 
-def write_version_py(filename='ompy/version.py'):
+def write_version_py(filename='ompy/version_setup.py'):
     cnt = """
 # THIS FILE IS GENERATED FROM OMPY SETUP.PY
-#
+# State of last built is:
 short_version = '%(version)s'
 version = '%(version)s'
 full_version = '%(full_version)s'


### PR DESCRIPTION
The only problem with the current setup could be, that the version number may not match the git commit, as the version number is retrieved from setup.py's auto generated setup_version.py file.

The setup_version.py file can also be used for trouble shooting purposes, so to see when people have last run a `build` or `install` for the package (if cython modules changed).