### PR TITLE
Attempting to fix #80, Response.interpolate for different dtypes

### DIFF
--- a/ompy/decomposition.pyx
+++ b/ompy/decomposition.pyx
@@ -75,6 +75,7 @@ def nld_T_product(double[::1] nld, double[::1] T, double[::1] resolution,
     normalize(firstgen)
     return firstgen
 
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.embedsignature(True)
@@ -103,10 +104,19 @@ cdef int _index(double[:] array, double element) nogil:
             prev_distance = distance
     return i
 
+
+ctypedef fused number:
+    cython.short
+    cython.int
+    cython.long
+    cython.float
+    cython.double
+
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.embedsignature(True)
-def index(double[:] array, double element):
+def index(number[:] array, number element):
     """ Finds the index of the closest element in the array
 
     Unsafe.

--- a/ompy/gauss_smoothing.pyx
+++ b/ompy/gauss_smoothing.pyx
@@ -1,13 +1,20 @@
 import os
 import numpy as np
+cimport cython
 cimport numpy as np
 
 from .matrix import to_plot_axis
 
 DTYPE = np.float64
 
+ctypedef fused number:
+    cython.short
+    cython.int
+    cython.long
+    cython.float
+    cython.double
 
-def gaussian(double[:] Emids, double mu, double sigma):
+def gaussian(number[:] Emids, number mu, double sigma):
     """
     Returns a normalized Gaussian supported on Emids.
 
@@ -15,9 +22,9 @@ def gaussian(double[:] Emids, double mu, double sigma):
     same units. In OMpy the default unit is keV.
 
     Args:
-        Emids (array, double): Array of energies to evaluate
+        Emids (array, number): Array of energies to evaluate
                                (center bin calibration)
-        mu (double): Centroid
+        mu (number): Centroid
         sigma (double): Standard deviation
     Returns:
         gaussian_array (array, double): Array of gaussian
@@ -42,7 +49,7 @@ def gaussian(double[:] Emids, double mu, double sigma):
     return gaussian_array
 
 
-def gauss_smoothing(double[:] array_in, double[:] E_array,
+def gauss_smoothing(double[:] array_in, number[:] E_array,
                     double[:] fwhm,
                     double truncate=3):
     """
@@ -50,7 +57,7 @@ def gauss_smoothing(double[:] array_in, double[:] E_array,
     of full-width-half-maximum FWHM. Preserves number of counts.
     Args:
         array_in (array, double): Array of inbound counts to be smoothed
-        E_array (array, double): Array with energy calibration of array_in, in
+        E_array (array, number): Array with energy calibration of array_in, in
                                  mid-bin calibration
         fwhm (array, double): The full-width-half-maximums. Need to be
                               same size as array_in
@@ -80,6 +87,7 @@ def gauss_smoothing(double[:] array_in, double[:] E_array,
                                 double sigma_current,
                                 double truncate=truncate):
         cdef int i_cut_low, i_cut_high
+        cdef double E_cut_low, E_cut_high
         E_cut_low = E_centroid_current - truncate * sigma_current
         i_cut_low = int((E_cut_low - a0) / a1)
         i_cut_low = max(0, i_cut_low)

--- a/ompy/rebin.pyx
+++ b/ompy/rebin.pyx
@@ -33,6 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
 cimport cython
+cimport numpy as np
 
 
 # We now need to fix a datatype for our arrays. I've used the variable
@@ -71,7 +72,7 @@ cdef double overlap(double edge_in_l, double edge_in_u,
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
 @cython.cdivision(True)
-def rebin_1D(double[:] counts, double[:] mids_in, double[:] mids_out):
+def rebin_1D(np.ndarray counts, np.ndarray mids_in, np.ndarray mids_out):
     """Rebin an array of counts from binning mids_in to binning mids_out
 
     Args:
@@ -125,8 +126,8 @@ def rebin_1D(double[:] counts, double[:] mids_in, double[:] mids_out):
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
 @cython.cdivision(True)
-def rebin_2D(double[:, :] counts, double[:] mids_in,
-             double[:] mids_out, int axis=0):
+def rebin_2D(np.ndarray counts, np.ndarray mids_in,
+             np.ndarray mids_out, int axis=0):
     """Rebin a matrix of counts from binning mids_in to binning mids_out
 
     This is a currently just a wrapper for rebin() to handle the logistics

--- a/ompy/vector.py
+++ b/ompy/vector.py
@@ -72,8 +72,12 @@ class Vector(AbstractArray):
             self.load(path)
         self.verify_integrity()
 
-    def verify_integrity(self):
+    def verify_integrity(self, check_equidistant: bool = False):
         """ Verify the internal consistency of the vector
+
+        Args:
+            check_equidistant (bool, optional): Check whether energy array
+                are equidistant spaced. Defaults to False.
 
         Raises:
             AssertionError or ValueError if any test fails
@@ -85,6 +89,9 @@ class Vector(AbstractArray):
         if self.std is not None:
             if self.std.shape != self.values.shape:
                 raise ValueError("std and values must have same shape")
+
+        if check_equidistant:
+            self.verify_equdistant(axis="x")
 
     def calibration(self) -> Dict[str, float]:
         """Calculate and return the calibration coefficients of the energy axes


### PR DESCRIPTION
Trying to fix #80, but doesn't work yet.

I tried to use the cython alternative to overloading, typefusing. It fixes the problem for the `index` function for which the problem was reported initially. However, the `rebin_1D` function did not get fixed by this, see the jupyter notebook.

 ``` pytb
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-14-2c4f551d59f6> in <module>
     12 # Magne recommends 1/10 of the actual resolution for unfolding purposes
     13 response = om.Response(folderpath)
---> 14 R_ompy_view, R_tab_view = response.interpolate(Eg.astype(int), fwhm_abs=fwhm_abs, return_table=True)
     15 R_ompy_unf, R_tab_unf = response.interpolate(Eg, fwhm_abs=fwhm_abs/10, return_table=True)
     16 R_ompy_view.plot(title="Response matrix", vmin=5e-5, vmax=5e-1,

~/Desktop/Masterthesis/misc/ompy/ompy/response.py in interpolate(self, Eout, fwhm_abs, return_table)
    330             # LOG.debug("Response for E: {E:.0f} calc. up to {Egmax:.0f}")
    331 
--> 332             compton = self.get_closest_compton(E)
    333 
    334             R_low, i_bsc = self.linear_backscatter(E, compton)

~/Desktop/Masterthesis/misc/ompy/ompy/response.py in get_closest_compton(self, E)
    431             cmp_low = self.cmp_matrix[ilow, :]
    432 
--> 433         cmp_low = rebin_1D(cmp_low, self.Ecmp_array, self.Eout)
    434         cmp_high = rebin_1D(cmp_high, self.Ecmp_array, self.Eout)
    435 

~/Desktop/Masterthesis/misc/ompy/ompy/rebin.pyx in ompy.rebin.rebin_1D()

ValueError: Buffer dtype mismatch, expected 'double' but got 'long'
```

@Caronthir: Any idea on this here? It's not super important, but would be nice to fix. Worst case we can just tell have a check/input type conversion for the interpolate class. But it'd be nice to know, I think :smile: 