### PR TITLE
Fixes #61, bug fix and change of fill_negative functions

### DIFF
--- a/ompy/firstgeneration.py
+++ b/ompy/firstgeneration.py
@@ -32,7 +32,7 @@ import copy
 import logging
 import termtables as tt
 import numpy as np
-from typing import Tuple, Optional
+from typing import Tuple, Optional, Callable
 from .matrix import Matrix
 from .vector import Vector
 from .library import div0
@@ -136,8 +136,7 @@ class FirstGeneration:
 
         final = Matrix(values=H, Eg=matrix.Eg, Ex=matrix.Ex)
         final.state = "firstgen"
-        final.fill_negative(window_size=10)
-        final.remove_negative()
+        self.remove_negative(final)
         return final
 
     def setup(self, matrix: Matrix) -> Tuple[Matrix, Matrix, Matrix]:
@@ -398,6 +397,17 @@ class FirstGeneration:
                     ag[i, :] += xs[i] * w[i, j] * div0(ag[j, :], xs[j])
 
         return ag
+
+    @staticmethod
+    def remove_negative(matrix: Matrix):
+        """ (Fill and) remove negative counts
+
+        Wrapper for Matrix.fill_and_remove_negative()
+
+        Args:
+            matrix: Input matrix
+        """
+        matrix.fill_and_remove_negative()
 
 
 def normalize_rows(array: np.ndarray) -> np.ndarray:

--- a/ompy/firstgeneration.py
+++ b/ompy/firstgeneration.py
@@ -57,7 +57,7 @@ class FirstGeneration:
             for the multiplicity estimation. Can be either "statistical",
             or "total". Default is "statistical".
         window_size (int or np.ndarray): window_size for (fill and) remove
-            negatives on output. Defaults to 10.
+            negatives on output. Defaults to 20.
         statistical_upper (float): Threshold for upper limit in
             `statistical` multiplicity estimation. Defaults to 430 keV.
         statistical_lower (float): Threshold for lower limit in
@@ -87,7 +87,7 @@ class FirstGeneration:
     def __init__(self):
         self.num_iterations: int = 10
         self.multiplicity_estimation: str = 'statistical'
-        self.window_size = 10
+        self.window_size = 20
 
         self.statistical_upper: float = 430.0  # MAMA ThresSta
         self.statistical_lower: float = 200.0  # MAMA ThresTot

--- a/ompy/firstgeneration.py
+++ b/ompy/firstgeneration.py
@@ -56,7 +56,8 @@ class FirstGeneration:
         multiplicity_estimation (str): Selects which method should be used
             for the multiplicity estimation. Can be either "statistical",
             or "total". Default is "statistical".
-
+        window_size (int or np.ndarray): window_size for (fill and) remove
+            negatives on output. Defaults to 10.
         statistical_upper (float): Threshold for upper limit in
             `statistical` multiplicity estimation. Defaults to 430 keV.
         statistical_lower (float): Threshold for lower limit in
@@ -86,6 +87,7 @@ class FirstGeneration:
     def __init__(self):
         self.num_iterations: int = 10
         self.multiplicity_estimation: str = 'statistical'
+        self.window_size = 10
 
         self.statistical_upper: float = 430.0  # MAMA ThresSta
         self.statistical_lower: float = 200.0  # MAMA ThresTot
@@ -398,8 +400,7 @@ class FirstGeneration:
 
         return ag
 
-    @staticmethod
-    def remove_negative(matrix: Matrix):
+    def remove_negative(self, matrix: Matrix):
         """ (Fill and) remove negative counts
 
         Wrapper for Matrix.fill_and_remove_negative()
@@ -407,7 +408,7 @@ class FirstGeneration:
         Args:
             matrix: Input matrix
         """
-        matrix.fill_and_remove_negative()
+        matrix.fill_and_remove_negative(window_size=self.window_size)
 
 
 def normalize_rows(array: np.ndarray) -> np.ndarray:

--- a/ompy/library.py
+++ b/ompy/library.py
@@ -143,7 +143,7 @@ def fill_negative(array: np.ndarray,
         for i_Eg in np.where(row < 0)[0]:  # select bins with negative entries
             window_size_Eg = window_size[i_Eg]
             i_low = max(0, i_Eg - window_size_Eg)
-            i_high = min(N_Eg, i_Eg + window_size_Eg +1)
+            i_high = min(N_Eg, i_Eg + window_size_Eg + 1)
 
             # array of possible bins, sorted by distance to i_Eg
             window = np.arange(i_low, i_high)

--- a/ompy/matrix.py
+++ b/ompy/matrix.py
@@ -759,9 +759,15 @@ class Matrix(AbstractArray):
         """ Entries with negative values are set to 0 """
         self.values = np.where(self.values > 0, self.values, 0)
 
-    def fill_and_remove_negative(self, window_size: int):
+    def fill_and_remove_negative(self,
+                                 window_size: Tuple[int, np.ndarray] = 10):
         """ Combination of :meth:`ompy.Matrix.fill_negative` and
-        :meth:`ompy.Matrix.remove_negative` """
+        :meth:`ompy.Matrix.remove_negative`
+
+        Args:
+            window_size: See `fill_negative`. Defaults to 10 (arbitrary)!.
+            """
+
         self.fill_negative(window_size=window_size)
         self.remove_negative()
 

--- a/ompy/matrix.py
+++ b/ompy/matrix.py
@@ -760,12 +760,12 @@ class Matrix(AbstractArray):
         self.values = np.where(self.values > 0, self.values, 0)
 
     def fill_and_remove_negative(self,
-                                 window_size: Tuple[int, np.ndarray] = 10):
+                                 window_size: Tuple[int, np.ndarray] = 20):
         """ Combination of :meth:`ompy.Matrix.fill_negative` and
         :meth:`ompy.Matrix.remove_negative`
 
         Args:
-            window_size: See `fill_negative`. Defaults to 10 (arbitrary)!.
+            window_size: See `fill_negative`. Defaults to 20 (arbitrary)!.
             """
 
         self.fill_negative(window_size=window_size)

--- a/ompy/unfolder.py
+++ b/ompy/unfolder.py
@@ -79,7 +79,7 @@ class Unfolder:
         minimum_iterations (int, optional): Minimum number of iterations.
             Defaults to 3.
         window_size (int or np.ndarray): window_size for  (fill and) remove
-            negatives on output. Defaults to 10.
+            negatives on output. Defaults to 20.
         use_compton_subtraction (bool, optional): Set usage of Compton
             subtraction method. Defaults to `True`.
         response_tab (DataFrame, optional): If `use_compton_subtraction=True`
@@ -105,7 +105,7 @@ class Unfolder:
         self.num_iter = num_iter
         self.weight_fluctuation: float = 0.2
         self.minimum_iterations: int = 3
-        self.window_size = 10
+        self.window_size = 20
 
         self._R: Optional[Matrix] = response
         self.raw: Optional[Matrix] = None

--- a/ompy/unfolder.py
+++ b/ompy/unfolder.py
@@ -78,6 +78,8 @@ class Unfolder:
              fluctuations. Defaults to 0.2
         minimum_iterations (int, optional): Minimum number of iterations.
             Defaults to 3.
+        window_size (int or np.ndarray): window_size for  (fill and) remove
+            negatives on output. Defaults to 10.
         use_compton_subtraction (bool, optional): Set usage of Compton
             subtraction method. Defaults to `True`.
         response_tab (DataFrame, optional): If `use_compton_subtraction=True`
@@ -103,6 +105,7 @@ class Unfolder:
         self.num_iter = num_iter
         self.weight_fluctuation: float = 0.2
         self.minimum_iterations: int = 3
+        self.window_size = 10
 
         self._R: Optional[Matrix] = response
         self.raw: Optional[Matrix] = None
@@ -427,8 +430,7 @@ class Unfolder:
 
         return unfolded
 
-    @staticmethod
-    def remove_negative(matrix: Matrix):
+    def remove_negative(self, matrix: Matrix):
         """ (Fill and) remove negative counts
 
         Wrapper for Matrix.fill_and_remove_negative()
@@ -436,7 +438,7 @@ class Unfolder:
         Args:
             matrix: Input matrix
         """
-        matrix.fill_and_remove_negative()
+        matrix.fill_and_remove_negative(window_size=self.window_size)
 
 
 def shift(counts_in, E_array_in, energy_shift):

--- a/ompy/unfolder.py
+++ b/ompy/unfolder.py
@@ -30,7 +30,7 @@ import numpy as np
 import pandas
 import logging
 import warnings
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Callable
 import termtables as tt
 from scipy.ndimage import gaussian_filter1d
 from copy import copy
@@ -78,8 +78,6 @@ class Unfolder:
              fluctuations. Defaults to 0.2
         minimum_iterations (int, optional): Minimum number of iterations.
             Defaults to 3.
-        window_size (float or int?, optional): window_size for fill negatives
-            on output. Defaults to 10.
         use_compton_subtraction (bool, optional): Set usage of Compton
             subtraction method. Defaults to `True`.
         response_tab (DataFrame, optional): If `use_compton_subtraction=True`
@@ -91,7 +89,6 @@ class Unfolder:
         iscores (np.ndarray, optional): Selected iteration number in the
             unfolding. The unfolding and selection is performed independently
             for each `Ex` row, thus this is an array with `len(raw.Ex)`.
-
     TODO:
         - Unfolding for a single spectrum (currently needs to be mocked as a
             Matrix).
@@ -106,7 +103,6 @@ class Unfolder:
         self.num_iter = num_iter
         self.weight_fluctuation: float = 0.2
         self.minimum_iterations: int = 3
-        self.window_size = 10
 
         self._R: Optional[Matrix] = response
         self.raw: Optional[Matrix] = None
@@ -115,9 +111,6 @@ class Unfolder:
         self.use_compton_subtraction: bool = True
         self.response_tab: Optional[pandas.DataFrame] = None
         self.FWHM_tweak_multiplier: Optional[dict[str, float]] = None
-
-        # remove negs. in final unfolded spectrum
-        self.remove_negatives: bool = True
 
         self.iscores: Optional[np.ndarray] = None
 
@@ -217,8 +210,7 @@ class Unfolder:
         unfolded = Matrix(unfolded, Eg=self.raw.Eg, Ex=self.raw.Ex)
         unfolded.state = "unfolded"
 
-        if self.remove_negatives:
-            unfolded.fill_and_remove_negative(window_size=self.window_size)
+        self.remove_negative(unfolded)
         return unfolded
 
     def step(self, unfolded: np.ndarray, folded: np.ndarray,
@@ -435,6 +427,16 @@ class Unfolder:
 
         return unfolded
 
+    @staticmethod
+    def remove_negative(matrix: Matrix):
+        """ (Fill and) remove negative counts
+
+        Wrapper for Matrix.fill_and_remove_negative()
+
+        Args:
+            matrix: Input matrix
+        """
+        matrix.fill_and_remove_negative()
 
 def shift(counts_in, E_array_in, energy_shift):
     """

--- a/ompy/unfolder.py
+++ b/ompy/unfolder.py
@@ -438,6 +438,7 @@ class Unfolder:
         """
         matrix.fill_and_remove_negative()
 
+
 def shift(counts_in, E_array_in, energy_shift):
     """
     Shift the counts_in array by amount energy_shift.


### PR DESCRIPTION
Fixed buggy fill negatives function and replaced it by a new method,
```
Fill negative channels with positive counts from neighboring channels.

The idea is that the negative counts are somehow connected to the (γ-ray)
resolution and should thus be filled from a channel within the resolution.

This implementation loops through the closest channels with positive number
of counts to fill the channle(s) with negative counts. Note that it can
happen that some bins will remain with negative counts (if not enough bins
with possitive counts are available within the window_size) .

The routine is performed for each Ex row independently.
```

Additionally changed code of FirstGeneration and Unfoder to have
easier access if someone want to replace the fill negatives function
by a custom function