### PR TITLE
Fix/fill negatives see PR #113 and #110

### DIFF
--- a/ompy/__init__.py
+++ b/ompy/__init__.py
@@ -25,7 +25,7 @@ else:
 
     # Simply import all functions and classes from all files to make them
     # available at the package level
-    from .library import div0, fill_negative
+    from .library import div0, fill_negative_gauss, fill_negative_max
     from .spinfunctions import SpinFunctions
     from .abstractarray import AbstractArray
     from .matrix import Matrix

--- a/ompy/firstgeneration.py
+++ b/ompy/firstgeneration.py
@@ -56,8 +56,6 @@ class FirstGeneration:
         multiplicity_estimation (str): Selects which method should be used
             for the multiplicity estimation. Can be either "statistical",
             or "total". Default is "statistical".
-        window_size (int or np.ndarray): window_size for (fill and) remove
-            negatives on output. Defaults to 20.
         statistical_upper (float): Threshold for upper limit in
             `statistical` multiplicity estimation. Defaults to 430 keV.
         statistical_lower (float): Threshold for lower limit in
@@ -87,7 +85,6 @@ class FirstGeneration:
     def __init__(self):
         self.num_iterations: int = 10
         self.multiplicity_estimation: str = 'statistical'
-        self.window_size = 20
 
         self.statistical_upper: float = 430.0  # MAMA ThresSta
         self.statistical_lower: float = 200.0  # MAMA ThresTot
@@ -401,14 +398,15 @@ class FirstGeneration:
         return ag
 
     def remove_negative(self, matrix: Matrix):
-        """ (Fill and) remove negative counts
+        """ Wrapper for Matrix.remove_negative()
 
-        Wrapper for Matrix.fill_and_remove_negative()
+        Put in as an extra method to facilitate replacing this by eg.
+        `fill_and_remove_negatve`
 
         Args:
             matrix: Input matrix
         """
-        matrix.fill_and_remove_negative(window_size=self.window_size)
+        matrix.remove_negative()
 
 
 def normalize_rows(array: np.ndarray) -> np.ndarray:

--- a/ompy/matrix.py
+++ b/ompy/matrix.py
@@ -42,7 +42,7 @@ from .decomposition import index
 from .filehandling import (mama_read, mama_write,
                            save_numpy_2D, load_numpy_2D, save_tar, load_tar,
                            filetype_from_suffix)
-from .library import div0, fill_negative, diagonal_elements
+from .library import div0, fill_negative_gauss, diagonal_elements
 from .matrixstate import MatrixState
 from .rebin import rebin_2D
 from .vector import Vector
@@ -752,16 +752,22 @@ class Matrix(AbstractArray):
         return diagonal_elements(self.values)
 
     def fill_negative(self, window_size: int):
-        """ Wrapper for :func:`ompy.fill_negative` """
-        self.values = fill_negative(self.values, window_size)
+        """ Wrapper for :func:`ompy.fill_negative_gauss` """
+        self.values = fill_negative_gauss(self.values, self.Eg, window_size)
 
     def remove_negative(self):
         """ Entries with negative values are set to 0 """
         self.values = np.where(self.values > 0, self.values, 0)
 
-    def fill_and_remove_negative(self, window_size: int):
+    def fill_and_remove_negative(self,
+                                 window_size: Tuple[int, np.ndarray] = 20):
         """ Combination of :meth:`ompy.Matrix.fill_negative` and
-        :meth:`ompy.Matrix.remove_negative` """
+        :meth:`ompy.Matrix.remove_negative`
+
+        Args:
+            window_size: See `fill_negative`. Defaults to 20 (arbitrary)!.
+            """
+
         self.fill_negative(window_size=window_size)
         self.remove_negative()
 

--- a/ompy/unfolder.py
+++ b/ompy/unfolder.py
@@ -78,8 +78,6 @@ class Unfolder:
              fluctuations. Defaults to 0.2
         minimum_iterations (int, optional): Minimum number of iterations.
             Defaults to 3.
-        window_size (int or np.ndarray): window_size for  (fill and) remove
-            negatives on output. Defaults to 20.
         use_compton_subtraction (bool, optional): Set usage of Compton
             subtraction method. Defaults to `True`.
         response_tab (DataFrame, optional): If `use_compton_subtraction=True`
@@ -105,7 +103,6 @@ class Unfolder:
         self.num_iter = num_iter
         self.weight_fluctuation: float = 0.2
         self.minimum_iterations: int = 3
-        self.window_size = 20
 
         self._R: Optional[Matrix] = response
         self.raw: Optional[Matrix] = None
@@ -431,14 +428,15 @@ class Unfolder:
         return unfolded
 
     def remove_negative(self, matrix: Matrix):
-        """ (Fill and) remove negative counts
+        """ Wrapper for Matrix.remove_negative()
 
-        Wrapper for Matrix.fill_and_remove_negative()
+        Put in as an extra method to facilitate replacing this by eg.
+        `fill_and_remove_negatve`
 
         Args:
             matrix: Input matrix
         """
-        matrix.fill_and_remove_negative(window_size=self.window_size)
+        matrix.remove_negative()
 
 
 def shift(counts_in, E_array_in, energy_shift):


### PR DESCRIPTION
Fixed buggy fill negatives function and replaced it by two new methods,
either filling from a maximum close-by channel, or from the weighted maximum. where the weights are given by a gaussian function

After some discussion in PRs #110 and #113 we decided to include the two functions, but remove the "fill negatives" part from unfolding the the first generation method 