### PR TITLE
Keep negative entries by default. Solves #119.

### DIFF
--- a/ompy/ensemble.py
+++ b/ompy/ensemble.py
@@ -319,7 +319,6 @@ class Ensemble:
         if raw is None:
             LOG.debug("Raw matrix")
             raw = matrix - self.bg_ratio * bg
-            raw.remove_negative()
             raw.save(path)
         self.action_raw.act_on(raw)
         return raw
@@ -431,7 +430,6 @@ class Ensemble:
         std = np.sqrt(np.where(mat.values > 0, mat.values, 0))
         perturbed = rstate.normal(size=mat.shape, loc=mat.values,
                                   scale=std)
-        perturbed[perturbed < 0] = 0
         return perturbed
 
     def generate_poisson(self, state: str,

--- a/ompy/extractor.py
+++ b/ompy/extractor.py
@@ -224,7 +224,7 @@ class Extractor:
 
         """
         if np.any(matrix.values < 0):
-            raise ValueError("input matrix has to have positive entries only.")
+            LOG.debug("input matrix has negative entries.")
         if std is not None:
             std = std.copy()
             if np.any(std.values < 0):

--- a/ompy/firstgeneration.py
+++ b/ompy/firstgeneration.py
@@ -89,7 +89,7 @@ class FirstGeneration:
             raise ValueError("input matrix has to have positive Ex entries"
                              "only. Consider using `matrix.cut('Ex', Emin=0)`")
         if np.any(matrix.values < 0):
-            raise ValueError("input matrix has to have positive entries only.")
+            LOG.debug("input matrix has negative counts.")
 
         valley_correction = self.cut_valley_correction(matrix)
 
@@ -105,7 +105,6 @@ class FirstGeneration:
 
         final = Matrix(values=H, Eg=matrix.Eg, Ex=matrix.Ex)
         final.state = "firstgen"
-        self.remove_negative(final)
         return final
 
     def setup(self, matrix: Matrix) -> Tuple[Matrix, Matrix, Matrix]:
@@ -366,17 +365,6 @@ class FirstGeneration:
                     ag[i, :] += xs[i] * w[i, j] * div0(ag[j, :], xs[j])
 
         return ag
-
-    def remove_negative(self, matrix: Matrix):
-        """ Wrapper for Matrix.remove_negative()
-
-        Put in as an extra method to facilitate replacing this by eg.
-        `fill_and_remove_negatve`
-
-        Args:
-            matrix: Input matrix
-        """
-        matrix.remove_negative()
 
 
 def normalize_rows(array: np.ndarray) -> np.ndarray:

--- a/ompy/matrix.py
+++ b/ompy/matrix.py
@@ -612,7 +612,7 @@ class Matrix(AbstractArray):
     def trapezoid(self, Ex_min: float, Ex_max: float,
                   Eg_min: float, Eg_max: Optional[float] = None,
                   inplace: bool = True) -> Optional[Matrix]:
-        """Create a trapezoidal cut or mask delimited by the diagonal of the matrix
+        """Trapezoidal cut delimited by the Ex=Eg diagonal of the matrix
 
         Args:
             Ex_min: The bottom edge of the trapezoid
@@ -645,7 +645,7 @@ class Matrix(AbstractArray):
 
         dEg = Eg_max - Ex_max
         if dEg > 0:
-            binwidth = Eg[1]-Eg[0]
+            binwidth = matrix.Eg[1]-matrix.Eg[0]
             dEg = np.ceil(dEg/binwidth) * binwidth
         mask[Eg >= Ex + dEg] = True
         matrix[mask] = 0

--- a/ompy/unfolder.py
+++ b/ompy/unfolder.py
@@ -112,11 +112,12 @@ class Unfolder:
             raise ValueError("Must have equal energy binning.")
 
         LOG.debug("Check for negative counts.")
-        if np.any(self.raw.values < 0) or np.any(self.R.values < 0):
-            raise ValueError("Raw and response cannot have negative counts."
+        if np.any(self.R.values < 0):
+            raise ValueError("Response cannot have negative counts."
                              "Consider using fill_negatives and "
                              "remove_negatives on the input matixes.")
-
+        if np.any(self.raw.values < 0):
+            LOG.debug("Raw matrix has negative counts.")
         self.r = self.raw.values
 
     def apply(self, raw: Matrix,
@@ -182,8 +183,6 @@ class Unfolder:
 
         unfolded = Matrix(unfolded, Eg=self.raw.Eg, Ex=self.raw.Ex)
         unfolded.state = "unfolded"
-
-        self.remove_negative(unfolded)
         return unfolded
 
     def step(self, unfolded: np.ndarray, folded: np.ndarray,

--- a/release_note.md
+++ b/release_note.md
@@ -1,8 +1,16 @@
 # Release notes for OMpy
 
-## [Unreleased]
-Changes:
-- Fixed a bug where the `std` attribute of `Vector` was not saved to file.
+## v.1.2.0
+Most important changes:
+Changed:
+  - No removal of negative counts in Ensemble generation, Unfolder and Firstgen
+    any longer. These can de applied, if wanted, through actions, see #119.
+
+Fixed:
+  - Fixed a bug where the `std` attribute of `Vector` was not saved to file.
+
+Added:
+  - New response matrixes of OSCAR
 
 ## v.1.1.0
 Most important changes:

--- a/release_note.md
+++ b/release_note.md
@@ -8,6 +8,7 @@ Changed:
 
 Fixed:
   - Fixed a bug where the `std` attribute of `Vector` was not saved to file.
+  - Fixed trapezoidal cut (binwidth resulted in `nan`)
 
 Added:
   - New response matrixes of OSCAR

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ except ImportError:
 
 # Version rutine taken from numpy
 MAJOR = 1
-MINOR = 1
+MINOR = 2
 MICRO = 0
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Keep negative entries in Ensemble, Unfolder and Fristgen by default. 
With this, we may avoid a bias due to removal of negative counts, see #119.