### PR TITLE
Added note about GCC/gfortran 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ git clone --recurse https://github.com/oslocyclotronlab/ompy/
 where the `--recurse` flag specifies, that all submodules shall be downloaded as well.
 
 ### Dependencies
- - Get and compile MultiNest (use the cmake version from [github.com/JohannesBuchner/MultiNest](https://github.com/JohannesBuchner/MultiNest)). The goal is to create lib/libmultinest.so
+ - Get and compile MultiNest (use the cmake version from [github.com/JohannesBuchner/MultiNest](https://github.com/JohannesBuchner/MultiNest)). The goal is to create lib/libmultinest.so    
     ``` bash
     git clone https://github.com/JohannesBuchner/MultiNest
     cd MultiNest/build
@@ -57,7 +57,16 @@ where the `--recurse` flag specifies, that all submodules shall be downloaded as
     make
     sudo make install
     ```
-    Multinest had following hard dependencies: `lapack` and `blas`. To use MPI, additionally openmp has to be installed (probably does not work for MAC users, see below.). With apt-get you may fix the dependencies by:
+    :warning: If the `make` steps above fails it might be that you have gcc/gfortran version 10 or higher. To fix this issue use the following steps instead
+    ``` bash
+    git clone https://github.com/JohannesBuchner/MultiNest
+    cd MultiNest/build
+    cmake -DCMAKE_Fortran_FLAGS=-std=legacy ..
+    make
+    sudo make install
+    ```
+    
+    Multinest has following hard dependencies: `lapack` and `blas`. To use MPI, additionally openmp has to be installed (probably does not work for MAC users, see below.). With apt-get you may fix the dependencies by:
     ```bash
     sudo apt-get install liblapack-dev libblas-dev libomp-dev
     ```

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ where the `--recurse` flag specifies, that all submodules shall be downloaded as
     ``` bash
     git clone https://github.com/JohannesBuchner/MultiNest
     cd MultiNest/build
-    cmake -DCMAKE_Fortran_FLAGS=-std=legacy ..
+    cmake -DCMAKE_Fortran_FLAGS="-std=legacy" ..
     make
     sudo make install
     ```


### PR DESCRIPTION
Added a note on how to avoid compilation errors when compiling MultiNest on a system with GCC/gfortran v10 or higher as default compiler.

I will add a pull request to the multinest repo fixing the problem, see https://github.com/JohannesBuchner/MultiNest/pull/2