### PR TITLE
Fixes #150, glitch in initial guess for simnorm

### DIFF
--- a/ompy/normalizer_simultan.py
+++ b/ompy/normalizer_simultan.py
@@ -202,7 +202,7 @@ class NormalizerSimultan(AbstractNormalizer):
         nld = normalizer_nld.nld.transform(A, alpha, inplace=False)
         nld_model = lambda E: normalizer_nld.model(E, T=T, Eshift=Eshift)  # noqa
 
-        normalizer_gsf.normalize(nld=nld, nld_model=nld_model)
+        normalizer_gsf.normalize(nld=nld, nld_model=nld_model, alpha=alpha)
         guess["B"] = normalizer_gsf.res.pars["B"][0]
 
         guess_print = copy.deepcopy(guess)


### PR DESCRIPTION
Glich in running gsf normalization if nld was not normalized before. Now the initial guess alpha is always fed through to the initial guess of B.