### PR TITLE
Stats

### DIFF
--- a/ompy/__init__.py
+++ b/ompy/__init__.py
@@ -49,4 +49,3 @@ else:
     from .ensembleNormalizer import EnsembleNormalizer
     from .models import NormalizationParameters, ResultsNormalized
     from .introspection import logging, hooks
-    from .stats import normal, truncnorm

--- a/ompy/__init__.py
+++ b/ompy/__init__.py
@@ -49,3 +49,4 @@ else:
     from .ensembleNormalizer import EnsembleNormalizer
     from .models import NormalizationParameters, ResultsNormalized
     from .introspection import logging, hooks
+    from .stats import normal, truncnorm

--- a/ompy/normalizer_nld.py
+++ b/ompy/normalizer_nld.py
@@ -12,7 +12,7 @@ from scipy.optimize import differential_evolution
 from typing import Optional, Tuple, Any, Union, Callable, Dict
 from pathlib import Path
 
-from .stats import truncnorm
+from .stats import truncnorm_ppf
 from .vector import Vector
 from .library import self_if_none
 from .spinfunctions import SpinFunctions
@@ -339,7 +339,7 @@ class NormalizerNLD(AbstractNormalizer):
         def prior(cube, ndim, nparams):
             # NOTE: You may want to adjust this for your case!
             # truncated normal prior
-            cube[0] = truncnorm(cube[0], a_A, b_A)*sigma_A+mu_A
+            cube[0] = truncnorm_ppf(cube[0], a_A, b_A)*sigma_A+mu_A
             # log-uniform prior
             # if alpha = 1e2, it's between 1e1 and 1e3
             cube[1] = 10**(cube[1]*2 + (alpha_exponent-1))
@@ -347,8 +347,8 @@ class NormalizerNLD(AbstractNormalizer):
             # if T = 1e2, it's between 1e1 and 1e3
             cube[2] = 10**(cube[2]*2 + (T_exponent-1))
             # truncated normal prior
-            cube[3] = truncnorm.ppf(cube[3], a_Eshift, b_Eshift)*sigma_Eshift\
-                + mu_Eshift
+            cube[3] = truncnorm_ppf.ppf(cube[3], a_Eshift,
+                                        b_Eshift)*sigma_Eshift + mu_Eshift
 
             if np.isinf(cube[3]):
                 self.LOG.debug("Encountered inf in cube[3]:\n%s", cube[3])

--- a/ompy/normalizer_nld.py
+++ b/ompy/normalizer_nld.py
@@ -12,7 +12,7 @@ from scipy.optimize import differential_evolution
 from typing import Optional, Tuple, Any, Union, Callable, Dict
 from pathlib import Path
 
-from scipy.stats import truncnorm
+from .stats import truncnorm
 from .vector import Vector
 from .library import self_if_none
 from .spinfunctions import SpinFunctions
@@ -339,8 +339,7 @@ class NormalizerNLD(AbstractNormalizer):
         def prior(cube, ndim, nparams):
             # NOTE: You may want to adjust this for your case!
             # truncated normal prior
-            cube[0] = truncnorm.ppf(cube[0], a_A, b_A, loc=mu_A,
-                                    scale=sigma_A)
+            cube[0] = truncnorm(cube[0], a_A, b_A)*sigma_A+mu_A
             # log-uniform prior
             # if alpha = 1e2, it's between 1e1 and 1e3
             cube[1] = 10**(cube[1]*2 + (alpha_exponent-1))
@@ -348,9 +347,8 @@ class NormalizerNLD(AbstractNormalizer):
             # if T = 1e2, it's between 1e1 and 1e3
             cube[2] = 10**(cube[2]*2 + (T_exponent-1))
             # truncated normal prior
-            cube[3] = truncnorm.ppf(cube[3], a_Eshift, b_Eshift,
-                                    loc=mu_Eshift,
-                                    scale=sigma_Eshift)
+            cube[3] = truncnorm.ppf(cube[3], a_Eshift, b_Eshift)*sigma_Eshift\
+                + mu_Eshift
 
             if np.isinf(cube[3]):
                 self.LOG.debug("Encountered inf in cube[3]:\n%s", cube[3])

--- a/ompy/normalizer_simultan.py
+++ b/ompy/normalizer_simultan.py
@@ -6,7 +6,7 @@ import termtables as tt
 from numpy import ndarray
 from pathlib import Path
 from typing import Optional, Union, Tuple, Any, Callable, Dict, Iterable, List
-from scipy.stats import truncnorm
+#from scipy.stats import truncnorm
 import pymultinest
 import matplotlib.pyplot as plt
 from contextlib import redirect_stdout
@@ -20,6 +20,7 @@ from .normalizer_nld import NormalizerNLD
 from .normalizer_gsf import NormalizerGSF
 from .spinfunctions import SpinFunctions
 from .vector import Vector
+from .stats import truncnorm
 
 
 class NormalizerSimultan(AbstractNormalizer):
@@ -273,8 +274,8 @@ class NormalizerSimultan(AbstractNormalizer):
         def prior(cube, ndim, nparams):
             # NOTE: You may want to adjust this for your case!
             # truncated normal prior
-            cube[0] = truncnorm.ppf(cube[0], a_A, b_A, loc=mu_A,
-                                    scale=sigma_A)
+            cube[0] = truncnorm(cube[0], a_A, b_A)*sigma_A + mu_A
+
             # log-uniform prior
             # if alpha = 1e2, it's between 1e1 and 1e3
             cube[1] = 10**(cube[1]*2 + (alpha_exponent-1))
@@ -282,12 +283,10 @@ class NormalizerSimultan(AbstractNormalizer):
             # if T = 1e2, it's between 1e1 and 1e3
             cube[2] = 10**(cube[2]*2 + (T_exponent-1))
             # truncated normal prior
-            cube[3] = truncnorm.ppf(cube[3], a_Eshift, b_Eshift,
-                                    loc=mu_Eshift,
-                                    scale=sigma_Eshift)
+            cube[3] = truncnorm(cube[3], a_Eshift, b_Eshift)*sigma_Eshift \
+                + mu_Eshift
             # truncated normal prior
-            cube[4] = truncnorm.ppf(cube[4], a_B, b_B, loc=mu_B,
-                                    scale=sigma_B)
+            cube[4] = truncnorm(cube[4], a_B, b_B)*sigma_B + mu_B
 
             if np.isinf(cube[3]):
                 self.LOG.debug("Encountered inf in cube[3]:\n%s", cube[3])

--- a/ompy/normalizer_simultan.py
+++ b/ompy/normalizer_simultan.py
@@ -19,7 +19,7 @@ from .normalizer_nld import NormalizerNLD
 from .normalizer_gsf import NormalizerGSF
 from .spinfunctions import SpinFunctions
 from .vector import Vector
-from .stats import truncnorm
+from .stats import truncnorm_ppf
 
 
 class NormalizerSimultan(AbstractNormalizer):
@@ -273,7 +273,7 @@ class NormalizerSimultan(AbstractNormalizer):
         def prior(cube, ndim, nparams):
             # NOTE: You may want to adjust this for your case!
             # truncated normal prior
-            cube[0] = truncnorm(cube[0], a_A, b_A)*sigma_A + mu_A
+            cube[0] = truncnorm_ppf(cube[0], a_A, b_A)*sigma_A + mu_A
 
             # log-uniform prior
             # if alpha = 1e2, it's between 1e1 and 1e3
@@ -282,10 +282,10 @@ class NormalizerSimultan(AbstractNormalizer):
             # if T = 1e2, it's between 1e1 and 1e3
             cube[2] = 10**(cube[2]*2 + (T_exponent-1))
             # truncated normal prior
-            cube[3] = truncnorm(cube[3], a_Eshift, b_Eshift)*sigma_Eshift \
-                + mu_Eshift
+            cube[3] = truncnorm_ppf(cube[3], a_Eshift,
+                                    b_Eshift)*sigma_Eshift + mu_Eshift
             # truncated normal prior
-            cube[4] = truncnorm(cube[4], a_B, b_B)*sigma_B + mu_B
+            cube[4] = truncnorm_ppf(cube[4], a_B, b_B)*sigma_B + mu_B
 
             if np.isinf(cube[3]):
                 self.LOG.debug("Encountered inf in cube[3]:\n%s", cube[3])

--- a/ompy/normalizer_simultan.py
+++ b/ompy/normalizer_simultan.py
@@ -6,7 +6,6 @@ import termtables as tt
 from numpy import ndarray
 from pathlib import Path
 from typing import Optional, Union, Tuple, Any, Callable, Dict, Iterable, List
-#from scipy.stats import truncnorm
 import pymultinest
 import matplotlib.pyplot as plt
 from contextlib import redirect_stdout

--- a/release_note.md
+++ b/release_note.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 Changes:
 - Fixed a bug where the `std` attribute of `Vector` was not saved to file.
+- Reimplemented PPF for normal distribution and truncated normal distribution in C++ for improved performance (about 300% faster than the SciPy implementation!).
 
 ## v.1.1.0
 Most important changes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@
  uncertainties>=3.0.3
  tqdm
  pathos
+ pybind11

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,8 @@ ext_modules_pybind11 = [
         Pybind11Extension("ompy.stats",
                           ["src/stats.cpp"],
                           extra_compile_args=["-std=c++11", "-mfpmath=sse",
-                                              "-O3", "-funroll-loops", "-march=native"])
+                                              "-O3", "-funroll-loops",
+                                              "-march=native"])
 ]
 
 install_requires = numpy.loadtxt("requirements.txt", dtype="str").tolist()

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ import os
 import builtins
 import platform
 from ctypes.util import find_library
+from pybind11.setup_helpers import Pybind11Extension
 
 try:
     from Cython.Build import cythonize
@@ -151,6 +152,13 @@ ext_modules = [
         Extension("ompy.gauss_smoothing", ["ompy/gauss_smoothing.pyx"], include_dirs=[numpy.get_include()]),
         ]
 
+ext_modules_pybind11 = [
+        Pybind11Extension("ompy.stats",
+                          ["src/stats.cpp"],
+                          extra_compile_args=["-std=c++11", "-mfpmath=sse",
+                                              "-O3", "-funroll-loops", "-march=native"])
+]
+
 install_requires = numpy.loadtxt("requirements.txt", dtype="str").tolist()
 setup(name='OMpy',
       version=get_version_info()[0],
@@ -164,7 +172,7 @@ setup(name='OMpy',
                             compiler_directives={'language_level': "3",
                                                  'embedsignature': True},
                             compile_time_env={"OPENMP": openmp}
-                            ),
+                            )+ext_modules_pybind11,
       zip_safe=False,
       install_requires=install_requires
       )

--- a/src/erfinv.hpp
+++ b/src/erfinv.hpp
@@ -45,6 +45,7 @@ constexpr double erfinv_d2 = 1.637067800;
 constexpr double erfinv_d1 = 3.543889200;
 constexpr double erfinv_d0 = 1;
 
+/* Compute the inverse error function */
 inline double erfinv(double x)
 {
 

--- a/src/erfinv.hpp
+++ b/src/erfinv.hpp
@@ -1,0 +1,79 @@
+/*
+   libit - Library for basic source and channel coding functions
+   Copyright (C) 2005-2005 Vivien Chappelier, Herve Jegou
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU General Public
+   License along with this library; if not, write to the Free
+   Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+/*
+	Implementation of inverse error function taken from libit on
+	3 nov. 2020. Redistributed with GPLv3.
+ */
+
+#pragma once
+
+#include <cmath>
+
+constexpr double erfinv_a3 = -0.140543331;
+constexpr double erfinv_a2 = 0.914624893;
+constexpr double erfinv_a1 = -1.645349621;
+constexpr double erfinv_a0 = 0.886226899;
+ 
+constexpr double erfinv_b4 = 0.012229801;
+constexpr double erfinv_b3 = -0.329097515;
+constexpr double erfinv_b2 = 1.442710462;
+constexpr double erfinv_b1 = -2.118377725;
+constexpr double erfinv_b0 = 1;
+
+constexpr double erfinv_c3 = 1.641345311;
+constexpr double erfinv_c2 = 3.429567803;
+constexpr double erfinv_c1 = -1.62490649;
+constexpr double erfinv_c0 = -1.970840454;
+
+constexpr double erfinv_d2 = 1.637067800;
+constexpr double erfinv_d1 = 3.543889200;
+constexpr double erfinv_d0 = 1;
+
+inline double erfinv(double x)
+{
+
+    if ( x <= -1 ){
+        return -INFINITY;
+    } else if ( x >= 1 ) {
+        return INFINITY;
+    }
+
+    double x2, r, y;
+    double sign_x = ( x < 0 ) ? -1 : 1;
+    x = fabs(x);
+
+    if ( x <= 0.7 ){
+
+        x2 = x * x;
+        r = x * (((erfinv_a3 * x2 + erfinv_a2) * x2 + erfinv_a1) * x2 + erfinv_a0);
+        r /= (((erfinv_b4 * x2 + erfinv_b3) * x2 + erfinv_b2) * x2 +erfinv_b1) * x2 + erfinv_b0;
+    } else {
+        y = sqrt(-log((1-x)/2.0));
+        r = (((erfinv_c3 * y + erfinv_c2) * y + erfinv_c1) * y + erfinv_c0);
+        r /= ((erfinv_d2 * y + erfinv_d1) * y + erfinv_d0);
+    }
+
+    r = r * sign_x;
+    x = x * sign_x;
+
+    r -= (erf (r) - x) / (2 / sqrt (M_PI) * exp (-r * r));
+    r -= (erf (r) - x) / (2 / sqrt (M_PI) * exp (-r * r));
+
+    return r;
+}

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -1,0 +1,90 @@
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <cmath>
+
+namespace py = pybind11;
+
+double erfinv(double x);
+double normal(double x);
+double truncnorm(double x, double alpha, double beta);
+
+constexpr double sqrt2 = 1.41421356237309504880168872420969807856967187;
+constexpr double erfinv_a3 = -0.140543331;
+constexpr double erfinv_a2 = 0.914624893;
+constexpr double erfinv_a1 = -1.645349621;
+constexpr double erfinv_a0 = 0.886226899;
+ 
+constexpr double erfinv_b4 = 0.012229801;
+constexpr double erfinv_b3 = -0.329097515;
+constexpr double erfinv_b2 = 1.442710462;
+constexpr double erfinv_b1 = -2.118377725;
+constexpr double erfinv_b0 = 1;
+
+constexpr double erfinv_c3 = 1.641345311;
+constexpr double erfinv_c2 = 3.429567803;
+constexpr double erfinv_c1 = -1.62490649;
+constexpr double erfinv_c0 = -1.970840454;
+
+constexpr double erfinv_d2 = 1.637067800;
+constexpr double erfinv_d1 = 3.543889200;
+constexpr double erfinv_d0 = 1;
+
+
+double normal(double x)
+{
+    return sqrt2*erfinv(2*x - 1);
+}
+
+
+double truncnorm(double x, double alpha = -INFINITY, double beta = INFINITY)
+{
+    double a = 0.5*(1 + erf(alpha/sqrt2));
+    double b = 0.5*(1 + erf(beta/sqrt2));
+    return sqrt2*erfinv(2*(x*(b-a) + a) - 1);
+}
+
+
+
+double erfinv(double x)
+{
+
+    if ( x <= -1 ){
+        return -INFINITY;
+    } else if ( x >= 1 ) {
+        return INFINITY;
+    }
+
+    double x2, r, y;
+    double sign_x = ( x < 0 ) ? -1 : 1;
+    x = fabs(x);
+
+    if ( x <= 0.7 ){
+
+        x2 = x * x;
+        r = x * (((erfinv_a3 * x2 + erfinv_a2) * x2 + erfinv_a1) * x2 + erfinv_a0);
+        r /= (((erfinv_b4 * x2 + erfinv_b3) * x2 + erfinv_b2) * x2 +erfinv_b1) * x2 + erfinv_b0;
+    } else {
+        y = sqrt(-log((1-x)/2.0));
+        r = (((erfinv_c3 * y + erfinv_c2) * y + erfinv_c1) * y + erfinv_c0);
+        r /= ((erfinv_d2 * y + erfinv_d1) * y + erfinv_d0);
+    }
+
+    r = r * sign_x;
+    x = x * sign_x;
+
+    r -= (erf (r) - x) / (2 / sqrt (M_PI) * exp (-r * r));
+    r -= (erf (r) - x) / (2 / sqrt (M_PI) * exp (-r * r));
+
+    return r;
+}
+
+
+PYBIND11_MODULE(stats, m) {
+    m.doc() = "Implementation of quantile functions in C++";
+
+    m.def("normal", &normal, "Transforms a uniform RV [0,1] number to a Gaussian RV.");
+    m.def("normal_vec", py::vectorize(normal), "Vectorized version of normal.");
+    m.def("truncnorm", &truncnorm, "Transforms a uniform RV [0,1] number to a truncateed Gaussian RV.");
+    m.def("truncnorm_vec", py::vectorize(truncnorm), "Vectorized version of truncnorm.");
+}

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -3,41 +3,20 @@
 #include <pybind11/numpy.h>
 #include <cmath>
 
+#include "erfinv.hpp"
+
+
 namespace py = pybind11;
-
-double erfinv(double x);
-double normal(double x);
-double truncnorm(double x, double alpha, double beta);
-
 constexpr double sqrt2 = 1.41421356237309504880168872420969807856967187;
-constexpr double erfinv_a3 = -0.140543331;
-constexpr double erfinv_a2 = 0.914624893;
-constexpr double erfinv_a1 = -1.645349621;
-constexpr double erfinv_a0 = 0.886226899;
- 
-constexpr double erfinv_b4 = 0.012229801;
-constexpr double erfinv_b3 = -0.329097515;
-constexpr double erfinv_b2 = 1.442710462;
-constexpr double erfinv_b1 = -2.118377725;
-constexpr double erfinv_b0 = 1;
-
-constexpr double erfinv_c3 = 1.641345311;
-constexpr double erfinv_c2 = 3.429567803;
-constexpr double erfinv_c1 = -1.62490649;
-constexpr double erfinv_c0 = -1.970840454;
-
-constexpr double erfinv_d2 = 1.637067800;
-constexpr double erfinv_d1 = 3.543889200;
-constexpr double erfinv_d0 = 1;
 
 
-double normal(double x)
+double normal_ppf(double x)
 {
     return sqrt2*erfinv(2*x - 1);
 }
 
 
-double truncnorm(double x, double alpha = -INFINITY, double beta = INFINITY)
+double truncnorm_ppf(double x, double alpha = -INFINITY, double beta = INFINITY)
 {
     double a = 0.5*(1 + erf(alpha/sqrt2));
     double b = 0.5*(1 + erf(beta/sqrt2));
@@ -45,46 +24,35 @@ double truncnorm(double x, double alpha = -INFINITY, double beta = INFINITY)
 }
 
 
-
-double erfinv(double x)
-{
-
-    if ( x <= -1 ){
-        return -INFINITY;
-    } else if ( x >= 1 ) {
-        return INFINITY;
-    }
-
-    double x2, r, y;
-    double sign_x = ( x < 0 ) ? -1 : 1;
-    x = fabs(x);
-
-    if ( x <= 0.7 ){
-
-        x2 = x * x;
-        r = x * (((erfinv_a3 * x2 + erfinv_a2) * x2 + erfinv_a1) * x2 + erfinv_a0);
-        r /= (((erfinv_b4 * x2 + erfinv_b3) * x2 + erfinv_b2) * x2 +erfinv_b1) * x2 + erfinv_b0;
-    } else {
-        y = sqrt(-log((1-x)/2.0));
-        r = (((erfinv_c3 * y + erfinv_c2) * y + erfinv_c1) * y + erfinv_c0);
-        r /= ((erfinv_d2 * y + erfinv_d1) * y + erfinv_d0);
-    }
-
-    r = r * sign_x;
-    x = x * sign_x;
-
-    r -= (erf (r) - x) / (2 / sqrt (M_PI) * exp (-r * r));
-    r -= (erf (r) - x) / (2 / sqrt (M_PI) * exp (-r * r));
-
-    return r;
-}
-
-
 PYBIND11_MODULE(stats, m) {
-    m.doc() = "Implementation of quantile functions in C++";
+    m.doc() = "Implementation of the inverse cumulative normal and truncated normal distribution";
 
-    m.def("normal", &normal, "Transforms a uniform RV [0,1] number to a Gaussian RV.");
-    m.def("normal_vec", py::vectorize(normal), "Vectorized version of normal.");
-    m.def("truncnorm", &truncnorm, "Transforms a uniform RV [0,1] number to a truncateed Gaussian RV.");
-    m.def("truncnorm_vec", py::vectorize(truncnorm), "Vectorized version of truncnorm.");
+    m.def("normal_ppf", &normal_ppf, R"PREFIX(Percent point function for the normal distribution.
+        For a normal distribution with mean μ and width σ use following transformation:
+        ```python
+        def transform_normal_ppf(x, μ, σ):
+            return normal_ppf(x)*σ + μ
+        ```
+        Args:
+            x: (float) quantile.
+        Returns: Inverse of the standardized cumulative normal distribution.)PREFIX");
+    
+    m.def("normal_ppf_vec", py::vectorize(normal_ppf), "Vectorized version of normal_ppf accepting numpy arrays.");
+    
+
+    m.def("truncnorm_ppf", &truncnorm_ppf, R"PREFIX(Percent point function for the truncated normal distribution.
+        For a truncated normal distribution with mean μ, width σ, lower limit a and upper limit b, use
+        following transformation:
+        ```python
+        def transform_truncnorm_ppf(x, μ, σ, a, b):
+            α = (a - μ)/σ
+            β = (b - μ)/σ
+            return truncnorm_ppf(x, α, β)*σ + μ
+        ```
+        Args:
+            x: (float) quantile.
+            alpha: (float)
+            beta: (float)
+        Returns: Inverse of the cumulative normal distribution.)PREFIX");
+    m.def("truncnorm_ppf_vec", py::vectorize(truncnorm_ppf), "Vectorized version of truncnorm_ppf accepting numpy arrays.");
 }

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -53,6 +53,6 @@ PYBIND11_MODULE(stats, m) {
             x: (float) quantile.
             alpha: (float)
             beta: (float)
-        Returns: Inverse of the cumulative normal distribution.)PREFIX");
+        Returns: Inverse of the cumulative normal distribution.)PREFIX", py::arg("alpha") = -INFINITY, py::arg("beta") = INFINITY);
     m.def("truncnorm_ppf_vec", py::vectorize(truncnorm_ppf), "Vectorized version of truncnorm_ppf accepting numpy arrays.");
 }

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -53,6 +53,6 @@ PYBIND11_MODULE(stats, m) {
             x: (float) quantile.
             alpha: (float)
             beta: (float)
-        Returns: Inverse of the cumulative normal distribution.)PREFIX", py::arg("alpha") = -INFINITY, py::arg("beta") = INFINITY);
+        Returns: Inverse of the cumulative normal distribution.)PREFIX");
     m.def("truncnorm_ppf_vec", py::vectorize(truncnorm_ppf), "Vectorized version of truncnorm_ppf accepting numpy arrays.");
 }

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -9,7 +9,17 @@ def test_normal():
     N = 10000
     x = np.random.rand(N)
 
-    norm_native = np.array([om.stats.normal(xi) for xi in x])
+    norm_native = np.array([om.stats.normal_ppf(xi) for xi in x])
+    norm_scipy = stats.norm.ppf(x)
+
+    assert_allclose(norm_native, norm_scipy)
+
+
+def test_normal_vec():
+    N = 10000
+    x = np.random.rand(N)
+
+    norm_native = om.stats.normal_ppf_vec(x)
     norm_scipy = stats.norm.ppf(x)
 
     assert_allclose(norm_native, norm_scipy)
@@ -22,7 +32,37 @@ def test_truncnorm():
     a = -5.
     b = 25.
 
-    truncnorm_native = np.array([om.stats.truncnorm(xi, a, b) for xi in x])
+    truncnorm_native = np.array([om.stats.truncnorm_ppf(xi, a, b) for xi in x])
+    truncnorm_scipy = stats.truncnorm.ppf(x, a, b)
+
+    assert_allclose(truncnorm_native, truncnorm_scipy)
+
+
+def test_truncnorm_vec():
+    N = 10000
+    x = np.random.rand(N)
+
+    a = -5.
+    b = 25.
+
+    truncnorm_native = om.stats.truncnorm_ppf_vec(x, a, b)
+    truncnorm_scipy = stats.truncnorm.ppf(x, a, b)
+
+    assert_allclose(truncnorm_native, truncnorm_scipy)
+
+    a = np.array([-5., 5.])
+    b = np.array([25., 25.])
+
+    x = np.random.rand()
+
+    truncnorm_native = om.stats.truncnorm_ppf_vec(x, a, b)
+    truncnorm_scipy = stats.truncnorm.ppf(x, a, b)
+
+    assert_allclose(truncnorm_native, truncnorm_scipy)
+
+    x = np.random.rand(2)
+
+    truncnorm_native = om.stats.truncnorm_ppf_vec(x, a, b)
     truncnorm_scipy = stats.truncnorm.ppf(x, a, b)
 
     assert_allclose(truncnorm_native, truncnorm_scipy)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,28 @@
+import pytest
+import ompy as om
+import numpy as np
+import scipy.stats as stats
+from numpy.testing import assert_allclose
+
+
+def test_normal():
+    N = 10000
+    x = np.random.rand(N)
+
+    norm_native = np.array([om.stats.normal(xi) for xi in x])
+    norm_scipy = stats.norm.ppf(x)
+
+    assert_allclose(norm_native, norm_scipy)
+
+
+def test_truncnorm():
+    N = 10000
+    x = np.random.rand(N)
+
+    a = -5.
+    b = 25.
+
+    truncnorm_native = np.array([om.stats.truncnorm(xi, a, b) for xi in x])
+    truncnorm_scipy = stats.truncnorm.ppf(x, a, b)
+
+    assert_allclose(truncnorm_native, truncnorm_scipy)


### PR DESCRIPTION
I've re-implemented the PPF transformation for both the normal distribution and the truncated normal distribution in C++. Currently we are relying on the SciPy implementation which is very slow. With both of these transformations done in native code the execution time is about one order of magnitude faster than that of SciPy.

```python
import scipy.stats as stats
import ompy as om

%timeit om.stats.normal(0.5)
%timeit stats.norm.ppf(0.5)
%timeit om.stats.truncnorm(0.5, -10., 20.)
%timeit stats.truncnorm.ppf(0.5, -10., 20.)
```
```
349 ns ± 13.3 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
109 µs ± 1.25 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
429 ns ± 4.65 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
168 µs ± 2.11 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```