### PR TITLE
Store evidence

### DIFF
--- a/ompy/models.py
+++ b/ompy/models.py
@@ -456,6 +456,7 @@ class ResultsNormalized(Model):
         gsf: see below
         pars: see below
         samples: see below
+        evidence: see below
         nld_model: see below
         gsf_model_low: see below
         gsf_model_high: see below
@@ -472,6 +473,10 @@ class ResultsNormalized(Model):
     #: (List[Dict[str, Any]]): Samples from the posterior of the parameters
     samples: List[Dict[str, Any]] = field(default_factory=list,
             metadata='Samples from the posterior of the parameters')  # noqa
+    #: (Tuple of List[Tuple]): Evidence and error in evidence for model
+    evidence: Union[Tuple[float, float], List[Tuple[float, float]]] \
+        = field(default_factory=list,
+                metadata='Global evidence for the model')
     #: (List[Callable[..., Any]]): nld model for each nld
     nld_model: List[Callable[..., Any]] = field(default_factory=list,
             metadata='nld model')  # noqa

--- a/ompy/normalizer_nld.py
+++ b/ompy/normalizer_nld.py
@@ -212,7 +212,7 @@ class NormalizerNLD(AbstractNormalizer):
         # Use DE to get an inital guess before optimizing
         args, guess = self.initial_guess(limit_low, limit_high)
         # Optimize using multinest
-        popt, samples = self.optimize(num, args, guess)
+        popt, samples, evidence = self.optimize(num, args, guess)
 
         transformed = nld.transform(popt['A'][0], popt['alpha'][0],
                                     inplace=False)
@@ -223,6 +223,7 @@ class NormalizerNLD(AbstractNormalizer):
         self.res.nld = transformed
         self.res.pars = popt
         self.res.samples = samples
+        self.res.evidence = evidence
         ext_model = lambda E: self.model(E, T=popt['T'][0],
                                          Eshift=popt['Eshift'][0])
         self.res.nld_model = ext_model
@@ -379,6 +380,8 @@ class NormalizerNLD(AbstractNormalizer):
                                         outputfiles_basename=str(path))
 
         stats = analyzer.get_stats()
+        
+        evidence = (stats['global evidence'], stats['global evidence error'])
 
         samples = analyzer.get_equal_weighted_posterior()[:, :-1]
         samples = dict(zip(names, samples.T))
@@ -399,7 +402,7 @@ class NormalizerNLD(AbstractNormalizer):
         self.LOG.info("Multinest results:\n%s", tt.to_string([vals],
                       header=['A', 'α [MeV⁻¹]', 'T [MeV]', 'Eshift [MeV]']))
 
-        return popt, samples
+        return popt, samples, evidence
 
     def plot(self, *, ax: Any = None,
              add_label: bool = True,

--- a/ompy/normalizer_nld.py
+++ b/ompy/normalizer_nld.py
@@ -380,7 +380,6 @@ class NormalizerNLD(AbstractNormalizer):
                                         outputfiles_basename=str(path))
 
         stats = analyzer.get_stats()
-        
         evidence = (stats['global evidence'], stats['global evidence error'])
 
         samples = analyzer.get_equal_weighted_posterior()[:, :-1]

--- a/ompy/normalizer_simultan.py
+++ b/ompy/normalizer_simultan.py
@@ -155,10 +155,11 @@ class NormalizerSimultan(AbstractNormalizer):
         # Use DE to get an inital guess before optimizing
         args_nld, guess = self.initial_guess()
         # Optimize using multinest
-        popt, samples = self.optimize(num, args_nld, guess)
+        popt, samples, evidence = self.optimize(num, args_nld, guess)
 
         self.res.pars = popt
         self.res.samples = samples
+        self.res.evidence = evidence
 
         # reset
         if self.std_fake_nld is True:
@@ -320,6 +321,7 @@ class NormalizerSimultan(AbstractNormalizer):
                                         outputfiles_basename=str(path))
 
         stats = analyzer.get_stats()
+        evidence = (stats['global evidence'], stats['global evidence error'])
 
         samples = analyzer.get_equal_weighted_posterior()[:, :-1]
         samples = dict(zip(names, samples.T))
@@ -344,7 +346,7 @@ class NormalizerSimultan(AbstractNormalizer):
         # reset state
         self.normalizer_gsf.norm_pars = norm_pars_org
 
-        return popt, samples
+        return popt, samples, evidence
 
     def lnlike(self, x: Tuple[float, float, float, float, float],
                args_nld: Iterable) -> float:

--- a/release_note.md
+++ b/release_note.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 Changes:
 - Fixed a bug where the `std` attribute of `Vector` was not saved to file.
+- Added `evidence` attribute to the `ResultsNormalized` class such that the global evidence of the Bayesian fit
+  are stored with the results.
 
 ## v.1.1.0
 Most important changes:


### PR DESCRIPTION
I've added an attribute to the `ResultsNormalized` to store the global evidence from the MultiNest results. Could be useful down the line.