### PR TITLE
Matrix infer shape

### DIFF
--- a/ompy/__init__.py
+++ b/ompy/__init__.py
@@ -30,7 +30,7 @@ else:
     from .library import div0, fill_negative_gauss, fill_negative_max
     from .spinfunctions import SpinFunctions
     from .abstractarray import AbstractArray
-    from .matrix import Matrix
+    from .matrix import Matrix, ZerosMatrix
     from .models import Model, NormalizationParameters, ResultsNormalized
     from .vector import Vector
     from .unfolder import Unfolder

--- a/ompy/matrix.py
+++ b/ompy/matrix.py
@@ -770,7 +770,6 @@ class Matrix(AbstractArray):
         """
         self.values[index(self.Ex, Ex)][index(self.Eg, Eg)] += count
 
-
     def fill_negative(self, window_size: int):
         """ Wrapper for :func:`ompy.fill_negative_gauss` """
         self.values = fill_negative_gauss(self.values, self.Eg, window_size)

--- a/ompy/matrix.py
+++ b/ompy/matrix.py
@@ -109,9 +109,14 @@ class Matrix(AbstractArray):
         if shape is not None:
             warnings.warn("Creating a Matrix with zeros as entries by the "
                           "shape argument is depreciated. Use ZerosMatrix "
-                          "instead.", DeprecationWarning())
-            return ZerosMatrix(shape=shape, Ex=Ex, Eg=Eg,
-                               std=std, state=state)
+                          "instead.", DeprecationWarning)
+            values = ZerosMatrix(shape=shape, Ex=Ex, Eg=Eg).values
+
+        if values is None and Ex is not None and Eg is not None:
+            warnings.warn("Creating a Matrix with zeros as entries only"
+                          "providing Ex and Eg is is depreciated. Use "
+                          "ZerosMatrix instead.", DeprecationWarning)
+            values = ZerosMatrix(Ex=Ex, Eg=Eg).values
 
         self.values = np.asarray(values, dtype=float).copy()
 
@@ -766,6 +771,7 @@ class Matrix(AbstractArray):
             count: (Optional) number to add to the bin.
         Returns: None
         """
+        print(Eg, Eg, self.values)
         self.values[index(self.Ex, Ex)][index(self.Eg, Eg)] += count
 
     def fill_negative(self, window_size: int):
@@ -929,7 +935,6 @@ class ZerosMatrix(Matrix):
                                      "*both* Eg and Ex are given.")
 
         values = np.zeros(shape, dtype=float)
-
         if std:
             self.std = np.zeros(shape, dtype=float)
         else:

--- a/ompy/matrix.py
+++ b/ompy/matrix.py
@@ -108,6 +108,10 @@ class Matrix(AbstractArray):
         if shape is not None and values is not None:
             raise ValueError("'shape' and 'values' are exclusive")
 
+        # Case if Eg and Ex are given but no shape
+        if Eg is not None and Ex is not None and shape is None and values is None:  # noqa
+            shape = (len(Ex), len(Eg))
+
         if shape is not None:
             self.values = np.zeros(shape, dtype=float)
         else:

--- a/ompy/matrix.py
+++ b/ompy/matrix.py
@@ -766,12 +766,10 @@ class Matrix(AbstractArray):
     def fill(self, Eg: float, Ex: float, count: Optional[float] = 1) -> None:
         """ Add counts to the bin containing Eg and Ex.
         Args:
-            Eg: (float) x-axis value
-            Ex: (float) y-axis values
-            count: (Optional) number to add to the bin.
-        Returns: None
+            Eg (float): Eg energy value (x-axis value)
+            Ex (float): Ex energy value (y-axis value)
+            count (float, otional): Number to add to the bin. Defaults to 1.
         """
-        print(Eg, Eg, self.values)
         self.values[index(self.Ex, Ex)][index(self.Eg, Eg)] += count
 
     def fill_negative(self, window_size: int):

--- a/ompy/matrix.py
+++ b/ompy/matrix.py
@@ -99,7 +99,7 @@ class Matrix(AbstractArray):
             Ex: The excitation energies using midbinning.
             std: The standard deviations at each bin of `values`
             path: Load a Matrix from a given path
-            shape: Tuple (len(Ex), len(Ex)) to create a matrix with 0 counts.
+            shape: Tuple (len(Ex), len(Eg)) to create a matrix with 0 counts.
             state: An enum to keep track of what has been done to the matrix.
                 Can also be a str. like in ["raw", "unfolded", ...]
 

--- a/ompy/matrix.py
+++ b/ompy/matrix.py
@@ -760,6 +760,17 @@ class Matrix(AbstractArray):
         """
         return diagonal_elements(self.values)
 
+    def fill(self, Eg: float, Ex: float, count: Optional[float] = 1) -> None:
+        """ Add counts to the bin containing Eg and Ex.
+        Args:
+            Eg: (float) x-axis value
+            Ex: (float) y-axis values
+            count: (Optional) number to add to the bin.
+        Returns: None
+        """
+        self.values[index(self.Ex, Ex)][index(self.Eg, Eg)] += count
+
+
     def fill_negative(self, window_size: int):
         """ Wrapper for :func:`ompy.fill_negative_gauss` """
         self.values = fill_negative_gauss(self.values, self.Eg, window_size)

--- a/release_note.md
+++ b/release_note.md
@@ -1,9 +1,16 @@
 # Release notes for OMpy
 
 ## [Unreleased]
-Changes:
+Added:
+- `ZerosMatrix` as a derived class to create a matrix fill with zeros.
+- `fill` attribute for `Matrix`, to easily fill counts in a given bin containing (Ex, Eg). 
+
+Changed:
 - Fixed a bug where the `std` attribute of `Vector` was not saved to file.
 - Reimplemented PPF for normal distribution and truncated normal distribution in C++ for improved performance (about 300% faster than the SciPy implementation!).
+
+Deprecated:
+- `shape` argument of Matrix for creation of a matrix filled with zeros. Use `ZerosMatrix` instead.
 
 ## v.1.1.0
 Most important changes:
@@ -28,7 +35,7 @@ Several changes, most important:
 
 
 ## v0.9.1
-Changes:
+Changed:
 
 - corrected version number
 (v 0.9.0 has still v.0.8.0 as the version number)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -166,7 +166,7 @@ def test_save_which_error(Ex, Eg):
          ([0, 1, 2, 3, 7, 10.], [0, 1, 2, 3, 80, 90.])
          ])
 def test_infere_shape(Ex, Eg):
-    values = np.ones((len(Ex), len(Eg)), dtype="float")
+    values = np.zeros((len(Ex), len(Eg)), dtype="float")
     mat = om.Matrix(Ex=Ex, Eg=Eg)
     assert_equal(mat.values, values)
 

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -186,7 +186,7 @@ def test_fill_matrix():
     Ex = np.array([1., 2., 3.])
     Eg = np.array([1., 2., 3., 4., 5., 6.])
     values = np.zeros((len(Ex), len(Eg)))
-    mat = om.Matrix(Ex=Ex, Eg=Eg)
+    mat = om.ZerosMatrix(Ex=Ex, Eg=Eg)
 
     mat.fill(1.9, 2.4)
     values[1][1] += 1

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -160,6 +160,17 @@ def test_save_which_error(Ex, Eg):
         mat.save("/tmp/mat.npy", which='Im not real')
 
 
+@pytest.mark.parametrize(
+        "Ex,Eg",
+        [(np.linspace(0, 10., num=10), np.linspace(10, 20., num=15)),
+         ([0, 1, 2, 3, 7, 10.], [0, 1, 2, 3, 80, 90.])
+         ])
+def test_infere_shape(Ex, Eg):
+    values = np.ones((len(Ex), len(Eg)), dtype="float")
+    mat = om.Matrix(Ex=Ex, Eg=Eg)
+    assert_equal(mat.values, values)
+
+
 # This does not work as of now...
 # def test_mutable():
 #     E = np.array([0, 1, 2])

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -171,6 +171,24 @@ def test_infere_shape(Ex, Eg):
     assert_equal(mat.values, values)
 
 
+def test_fill_matrix():
+    """ TODO: add more cases such as making sure we are close to the correct
+    number, etc.
+    """
+    Ex = np.array([1., 2., 3.])
+    Eg = np.array([1., 2., 3., 4., 5., 6.])
+    values = np.zeros((len(Ex), len(Eg)))
+    mat = om.Matrix(Ex=Ex, Eg=Eg)
+
+    mat.fill(1.9, 2.4)
+    values[1][1] += 1
+    assert_equal(mat.values, values)
+
+    mat.fill(0., 6.)
+    values[-1][0] += 1
+    assert_equal(mat.values, values)
+
+
 # This does not work as of now...
 # def test_mutable():
 #     E = np.array([0, 1, 2])

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -165,10 +165,18 @@ def test_save_which_error(Ex, Eg):
         [(np.linspace(0, 10., num=10), np.linspace(10, 20., num=15)),
          ([0, 1, 2, 3, 7, 10.], [0, 1, 2, 3, 80, 90.])
          ])
-def test_infere_shape(Ex, Eg):
+def test_shape_ZerosMatrix(Ex, Eg):
     values = np.zeros((len(Ex), len(Eg)), dtype="float")
-    mat = om.Matrix(Ex=Ex, Eg=Eg)
+    mat = om.ZerosMatrix(Ex=Ex, Eg=Eg)
     assert_equal(mat.values, values)
+
+
+def test_ZerosMatrix_fail_without_enough_info():
+    energies = np.array([1, 2, 3])
+    with pytest.raises(AssertionError):
+        om.ZerosMatrix(Ex=energies)
+    with pytest.raises(AssertionError):
+        om.ZerosMatrix(Eg=energies)
 
 
 def test_fill_matrix():


### PR DESCRIPTION
The `Matrix` class can now infer the `shape` parameter at initialization if both `Ex` and `Eg` variables are set but shape is not. Also added the `fill` method to make it easy to add data to the histogram.