### PR TITLE
Fixed depricated changing of cmap

### DIFF
--- a/ompy/matrix.py
+++ b/ompy/matrix.py
@@ -291,7 +291,7 @@ class Matrix(AbstractArray):
             vmin: Minimum value for coloring in scaling
             vmax Maximum value for coloring in scaling
             add_cbar: Whether to add a colorbar. Defaults to True.
-            kwargs: Additional kwargs to plot command.
+            **kwargs: Additional kwargs to plot command.
 
         Returns:
             The ax used for plotting
@@ -388,7 +388,7 @@ class Matrix(AbstractArray):
             normalize: If True, normalize the counts to 1. Defaults to False.
             scale (optional, str): y-scale, i.e `log` or `linear`. Defaults to
                 "linear".
-            kwargs: Additional kwargs to plot command.
+            **kwargs: Additional kwargs to plot command.
 
         Raises:
             ValueError: If axis is not in [0, 1]
@@ -871,7 +871,7 @@ class Matrix(AbstractArray):
         """ Check whether `other` has equal binning as `self` within precision.
         Args:
             other (Matrix): Matrix to compare to.
-            kwargs: Additional kwargs to `np.allclose`.
+            **kwargs: Additional kwargs to `np.allclose`.
 
         Returns:
             bool (bool): Returns `True` if both arrays are equal  .

--- a/ompy/matrix.py
+++ b/ompy/matrix.py
@@ -277,7 +277,6 @@ class Matrix(AbstractArray):
              scale: Optional[str] = None,
              vmin: Optional[float] = None,
              vmax: Optional[float] = None,
-             cmap: Optional[Any] = None,
              midbin_ticks: bool = False,
              add_cbar: bool = True,
              **kwargs) -> Any:
@@ -325,13 +324,13 @@ class Matrix(AbstractArray):
         self.to_mid_bin()
 
         # Set entries of 0 to white
-        current_cmap = copy.copy(cmap if cmap is not None else cm.get_cmap())
+        current_cmap = copy.copy(cm.get_cmap())
         current_cmap.set_bad(color='white')
+        kwargs.setdefault('cmap', current_cmap)
         mask = np.isnan(self.values) | (self.values == 0)
         masked = np.ma.array(self.values, mask=mask)
 
-        lines = ax.pcolormesh(Eg, Ex, masked, norm=norm, cmap=current_cmap,
-                              **kwargs)
+        lines = ax.pcolormesh(Eg, Ex, masked, norm=norm, **kwargs)
         if midbin_ticks:
             ax.xaxis.set_major_locator(MeshLocator(self.Eg))
             ax.tick_params(axis='x', rotation=40)

--- a/ompy/matrix.py
+++ b/ompy/matrix.py
@@ -277,6 +277,7 @@ class Matrix(AbstractArray):
              scale: Optional[str] = None,
              vmin: Optional[float] = None,
              vmax: Optional[float] = None,
+             cmap: Optional[Any] = None,
              midbin_ticks: bool = False,
              add_cbar: bool = True,
              **kwargs) -> Any:
@@ -324,12 +325,13 @@ class Matrix(AbstractArray):
         self.to_mid_bin()
 
         # Set entries of 0 to white
-        current_cmap = cm.get_cmap()
+        current_cmap = copy.copy(cmap if cmap is not None else cm.get_cmap())
         current_cmap.set_bad(color='white')
         mask = np.isnan(self.values) | (self.values == 0)
         masked = np.ma.array(self.values, mask=mask)
 
-        lines = ax.pcolormesh(Eg, Ex, masked, norm=norm, **kwargs)
+        lines = ax.pcolormesh(Eg, Ex, masked, norm=norm, cmap=current_cmap,
+                              **kwargs)
         if midbin_ticks:
             ax.xaxis.set_major_locator(MeshLocator(self.Eg))
             ax.tick_params(axis='x', rotation=40)


### PR DESCRIPTION
In `Matrix.plot()` the global cmap is changed to set zero to white. Modifications to global cmap is being deprecated by matplotlib, thus a copy should be made before any changes can be made.

I've added an explicit keyword argument for cmap so that if a user given cmap is given it also will get zero counts set to white. Let me know what you think about it. It might make sense to not do that as well, or have a flag in addition to dictate if zero should be white or not.

A little more context:
```
WARNING:MainThread:py.warnings:ompy/ompy/matrix.py:329: MatplotlibDeprecationWarning: 
You are modifying the state of a globally registered colormap.
In future versions, you will not be able to modify a registered colormap in-place.
To remove this warning, you can make a copy of the colormap first.
cmap = copy.copy(mpl.cm.get_cmap("viridis"))
```