### PR TITLE
Updated travis to write out version numbers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,5 @@ install:
   - pip3 install -e .
 
 script:
+    - python check_env.py
     - pytest ./tests/

--- a/check_env.py
+++ b/check_env.py
@@ -1,0 +1,19 @@
+import numpy
+import cython
+import pandas
+import matplotlib
+import pymultinest
+import scipy
+import uncertainties
+import tqdm
+import pathos
+import pybind11
+
+from IPython import get_ipython
+ipython = get_ipython()
+
+import watermark
+
+
+ipython.magic("load_ext watermark")
+ipython.magic("watermark -m -u -d -v -iv -w")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@
  tqdm
  pathos
  pybind11>=2.6.0
+ ipython
+ watermark


### PR DESCRIPTION
Travis should write a list with versions of python, numpy etc. before running the test.