### PR TITLE
Added the option of passing kwargs to pandas

### DIFF
--- a/ompy/filehandling.py
+++ b/ompy/filehandling.py
@@ -310,18 +310,20 @@ def save_numpy_1D(values: np.ndarray, E: np.ndarray,
 
 def save_csv_1D(values: np.ndarray, E: np.ndarray,
                 std: Union[np.ndarray, None],
-                path: Union[str, Path]) -> None:
+                path: Union[str, Path], **kwargs) -> None:
     df = {'E': E, 'values': values}
     if std is not None:
         df['std'] = std
     df = pd.DataFrame(df)
-    df.to_csv(path, index=False)
+    kwargs.setdefault('index', False)
+    df.to_csv(path, **kwargs)
 
 
-def load_csv_1D(path: Union[str, Path]) -> Tuple[np.ndarray,
-                                                 np.ndarray,
-                                                 Union[np.ndarray, None]]:
-    df = pd.read_csv(path)
+def load_csv_1D(path: Union[str, Path],
+                **kwargs) -> Tuple[np.ndarray, 
+                                   np.ndarray,
+                                   Union[np.ndarray, None]]:
+    df = pd.read_csv(path, **kwargs)
     E = df['E'].to_numpy(copy=True)
     values = df['values'].to_numpy(copy=True)
     std = None

--- a/ompy/filehandling.py
+++ b/ompy/filehandling.py
@@ -320,7 +320,7 @@ def save_csv_1D(values: np.ndarray, E: np.ndarray,
 
 
 def load_csv_1D(path: Union[str, Path],
-                **kwargs) -> Tuple[np.ndarray, 
+                **kwargs) -> Tuple[np.ndarray,
                                    np.ndarray,
                                    Union[np.ndarray, None]]:
     df = pd.read_csv(path, **kwargs)

--- a/ompy/vector.py
+++ b/ompy/vector.py
@@ -37,7 +37,8 @@ class Vector(AbstractArray):
                  E: Optional[Iterable[float]] = None,
                  path: Optional[Union[str, Path]] = None,
                  std: Optional[Iterable[float]] = None,
-                 units: Optional[str] = "keV"):
+                 units: Optional[str] = "keV",
+                 **kwargs):
         """
         There are several ways to initialize
 
@@ -53,7 +54,7 @@ class Vector(AbstractArray):
             path: see above
             std: see above
             unit: see above
-
+            kwargs: arguments to the filereader (see pandas.read_csv)
         Raises:
            ValueError if the given arrays are of differing lenghts.
 
@@ -77,7 +78,7 @@ class Vector(AbstractArray):
         self.units = units
 
         if path is not None:
-            self.load(path)
+            self.load(path, **kwargs)
         self.verify_integrity()
 
     def __len__(self):
@@ -194,12 +195,13 @@ class Vector(AbstractArray):
                 warnings.warn("MaMa cannot store std. "
                               "Consider using another format")
         elif filetype == 'csv':
-            save_csv_1D(vector.values, vector.E, vector.std, path)
+            save_csv_1D(vector.values, vector.E, vector.std, path, **kwargs)
         else:
             raise ValueError(f"Unknown filetype {filetype}")
 
     def load(self, path: Union[str, Path],
-             filetype: Optional[str] = None) -> None:
+             filetype: Optional[str] = None,
+             **kwargs) -> None:
         """Load to a file of specified format
 
         Args:
@@ -231,7 +233,7 @@ class Vector(AbstractArray):
         elif filetype == 'mama':
             self.values, self.E = mama_read(path)
         elif filetype == 'csv':
-            self.values, self.E, self.std = load_csv_1D(path)
+            self.values, self.E, self.std = load_csv_1D(path, **kwargs)
         else:
             try:
                 self.values, self.E = mama_read(path)

--- a/release_note.md
+++ b/release_note.md
@@ -3,7 +3,8 @@
 ## [Unreleased]
 Added:
 - `ZerosMatrix` as a derived class to create a matrix fill with zeros.
-- `fill` attribute for `Matrix`, to easily fill counts in a given bin containing (Ex, Eg). 
+- `fill` attribute for `Matrix`, to easily fill counts in a given bin containing (Ex, Eg).
+- When saving and loading `Vector` from `csv` files one can now pass keyword arguments to the pandas `read_csv()` and `to_csv()` functions.
 
 Changed:
 - Fixed a bug where the `std` attribute of `Vector` was not saved to file.

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -46,6 +46,19 @@ def test_save_load_no_std():
         assert_allclose(vec_from_file.values, vals)
 
 
+def test_save_load_csv_with_kwargs():
+    E = np.linspace(0, 1, 100)
+    vals = np.linspace(2, 3.4, 100)
+    std = np.random.randn(100)*0.1
+
+    vec = om.Vector(values=vals, E=E, std=std)
+    vec.save('/tmp/test_csv.csv', sep="\t")
+    vec_from_file = om.Vector(path='/tmp/test_csv.csv', sep='\t')
+    assert_allclose(vec_from_file.E, vec.E)
+    assert_allclose(vec_from_file.values, vec.values)
+    assert_allclose(vec_from_file.std, vec.std)
+
+
 def test_save_load():
     E = np.linspace(0, 1, 100)
     vals = np.linspace(2, 3.4, 100)


### PR DESCRIPTION
During loading and saving of vectors to `csv` format we currently use pandas. Pandas has a lot of functionality while saving/loading of `csv` files, thus it could be useful to pass keyword arguments while saving or loading `csv` files.