### PR TITLE
Select units when saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ If you don't have OpenMP / have problems installing it (see above), you can inst
 We cleaned the repository from old comits clogging the repo (big data files that should never have been there). Unfortunetely, this has the sideeffect that the history had to be rewritten: Previous commits now have a different SHA1 (git version keys). If you need anything from the previous repo, see [ompy_Archive_Sept2019](https://github.com/oslocyclotronlab/ompy_Archive_Sept2019). This will unfortunately also destroy references in issues.
 The simplest way to get the new repo is to rerun the installation instructions below.
 
+#### Saving `Vector`´s in `MaMa` format
+The `MaMa` format has some limitation. Mainly the format will not be able to save the `std` attribute, meaning that error-bars will not be stored. The `MaMa` format is always in keV units, meaning that the `units` keyword in the `Vector.save` method is ignored.
+
 ## General usage
 All the functions and classes in the package are available in the main module. You get everything by importing the package
 

--- a/ompy/normalizer_nld.py
+++ b/ompy/normalizer_nld.py
@@ -680,7 +680,7 @@ def load_levels_discrete(path: Union[str, Path], energy: ndarray) -> Vector:
         A vector describing the levels
     """
     histogram, _ = load_discrete(path, energy, 0.1)
-    return Vector(values=histogram, E=energy)
+    return Vector(values=histogram, E=energy, units='MeV')
 
 
 def load_levels_smooth(path: Union[str, Path], energy: ndarray,
@@ -697,4 +697,5 @@ def load_levels_smooth(path: Union[str, Path], energy: ndarray,
         A vector describing the smoothed levels
     """
     histogram, smoothed = load_discrete(path, energy, resolution)
-    return Vector(values=smoothed if resolution > 0 else histogram, E=energy)
+    return Vector(values=smoothed if resolution > 0 else histogram, E=energy,
+                  units='MeV')

--- a/ompy/vector.py
+++ b/ompy/vector.py
@@ -169,16 +169,22 @@ class Vector(AbstractArray):
             filetype (str, optional): Filetype. Default uses
                 auto-recognition from suffix.
                 Options: ["numpy", "txt", "tar", "mama", "csv"]
+            units (str, optional): Units for the x-axis. Default
+                uses keV. Options: ["keV", "MeV", "same"]. "same"
+                option will use the current selected units of the vector.
             **kwargs: additional keyword arguments
 
         Raises:
-            ValueError: Filetype is not supported
+            ValueError: Filetype is not supported.
+            NotImplementedError: Unsupported units.
         """
         vector = self.copy()
         if units == 'keV':
             vector.to_keV()
         elif units == 'MeV':
             vector.to_MeV()
+        elif units == 'same':  # We don't change the units
+            pass
         else:
             raise NotImplementedError(f"Could not understand units={units}")
         path = Path(path) if isinstance(path, str) else path

--- a/ompy/vector.py
+++ b/ompy/vector.py
@@ -172,6 +172,7 @@ class Vector(AbstractArray):
             units (str, optional): Units for the x-axis. Default
                 uses keV. Options: ["keV", "MeV", "same"]. "same"
                 option will use the current selected units of the vector.
+                Note: This keyword is ignored when saving to "mama" type.
             **kwargs: additional keyword arguments
 
         Raises:
@@ -202,10 +203,15 @@ class Vector(AbstractArray):
             else:
                 save_tar([vector.values, vector.E], path)
         elif filetype == 'mama':
-            mama_write(self, path, comment="Made by OMpy", **kwargs)
             if self.std is not None:
                 warnings.warn("MaMa cannot store std. "
                               "Consider using another format")
+            if vector.units != 'keV':
+                warnings.warn("The MaMa format does not support storing "
+                              "spectra with other units than keV. "
+                              "`units` keyword will be ignored.")
+                vector.to_keV()
+            mama_write(self, path, comment="Made by OMpy", **kwargs)
         elif filetype == 'csv':
             save_csv_1D(vector.values, vector.E, vector.std, path, **kwargs)
         else:

--- a/ompy/vector.py
+++ b/ompy/vector.py
@@ -160,6 +160,7 @@ class Vector(AbstractArray):
 
     def save(self, path: Union[str, Path],
              filetype: Optional[str] = None,
+             units: Optional[str] = "keV",
              **kwargs) -> None:
         """Save to a file of specified format
 
@@ -174,7 +175,12 @@ class Vector(AbstractArray):
             ValueError: Filetype is not supported
         """
         vector = self.copy()
-        vector.to_keV()
+        if units == 'keV':
+            vector.to_keV()
+        elif units == 'MeV':
+            vector.to_MeV()
+        else:
+            raise NotImplementedError(f"Could not understand units={units}")
         path = Path(path) if isinstance(path, str) else path
         if filetype is None:
             filetype = filetype_from_suffix(path)

--- a/release_note.md
+++ b/release_note.md
@@ -5,10 +5,12 @@ Added:
 - `ZerosMatrix` as a derived class to create a matrix fill with zeros.
 - `fill` attribute for `Matrix`, to easily fill counts in a given bin containing (Ex, Eg).
 - When saving and loading `Vector` from `csv` files one can now pass keyword arguments to the pandas `read_csv()` and `to_csv()` functions.
+- Added a keyword (`units`) to select the energy units when saving a `Vector` to file.
 
 Changed:
 - Fixed a bug where the `std` attribute of `Vector` was not saved to file.
 - Reimplemented PPF for normal distribution and truncated normal distribution in C++ for improved performance (about 300% faster than the SciPy implementation!).
+- Fixed a potential bug where `units` attribute is set erroniously when reading the discrete level density from file (`load_levels_discrete` and `load_levels_discrete_smooth`).
 
 Deprecated:
 - `shape` argument of Matrix for creation of a matrix filled with zeros. Use `ZerosMatrix` instead.

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -32,6 +32,21 @@ def test_len():
     assert_equal(len(vec), N)
 
 
+def test_save_units():
+    E = np.arange(0, 5010, 10)
+    vals = np.random.random(len(E))
+
+    vec = om.Vector(values=vals, E=E)
+    vec.save("/tmp/units.txt", units='MeV')
+
+    vec_from_file = om.Vector(path="/tmp/units.txt", units='MeV')
+    assert_allclose(vec_from_file.E, E/1000.)
+    assert_allclose(vec_from_file.values, vals)
+
+    vec_from_file.to_keV()
+    assert_allclose(vec_from_file.E, vec.E)
+
+
 def test_save_load_no_std():
     E = np.linspace(0, 1, 100)
     vals = np.linspace(2, 3.4, 100)


### PR DESCRIPTION
The motivation of this PR is to add the option to ensure that exported data has the desired energy units (x-axis). When preparing figures for publication it may be that other plotting software such as ROOT may be preferable to ensure a consistent look and feel.

I've added a `units` keyword in the `save()` method of the vector to allow the user to select the units of the x-axis when exporting the object.

The current default behaviour is to save with keV units (same as before this PR), but this could be changed to save with the current selected units (either MeV or keV). Any thoughts?

Similar functionality could be added to the `Matrix` class but would need to add a `units` attribute. Currently I don't see the need, but maybe I should open an issue if anyone would like to implement it later?

I've also fixed a potential bug where the `units` attribute of the `Vector` returned by `load_levels_discrete` and `load_levels_discrete_smooth` would be wrong. See  commit 4634550769ff48854ea962f6b7bb74ae04ff080f.