### PR TITLE
Added spin distribution from Guttormsen et al., 2017, PRC 96, 024313 with a slightly different parameterization

### DIFF
--- a/ompy/spinfunctions.py
+++ b/ompy/spinfunctions.py
@@ -186,7 +186,7 @@ class SpinFunctions:
 
     def gDisc_and_sigmaSn(self, sigma2_disc: Tuple[float, float],
                           sigma2_Sn: Tuple[float, float],
-                          Ex: Optional[float, Sequence] = None) -> Union[float, Sequence]:  # noqa
+                          Ex: Optional[Union[float, Sequence]] = None) -> Union[float, Sequence]:  # noqa
         """
         Linear interpolation of the spin-cut between
         a spin cut "from the discrete levels" and a set
@@ -211,5 +211,5 @@ class SpinFunctions:
         y = [sigma2_disc[1], sigma2_Sn[1]]
         sigma2 = interp1d(x, y,
                           bounds_error=False,
-                          fill_value=(sigma2_disc[1], sigma2_Sn))
-        return sigma2
+                          fill_value=(sigma2_disc[1], sigma2_Sn[1]))
+        return sigma2(Ex)

--- a/tests/test_spindists.py
+++ b/tests/test_spindists.py
@@ -3,6 +3,7 @@ import ompy as om
 import numpy as np
 from numpy.testing import assert_allclose
 
+
 @pytest.mark.parametrize(
                 "spinpars",
                  [{"NLDa": 25.160, "Eshift": 0.120},
@@ -35,6 +36,10 @@ testdata = [("EB05", [4.2, 6.534],
             ("Disc_and_EB05", [1.5, 4.2, 6.534],   # combination of the above
              {"mass": 240, "NLDa": 25.506, "Eshift": 0.162, "Sn": 6.534,
               "sigma2_disc": [1.5, 3.6]},
+             [np.sqrt(3.6),
+              np.sqrt(y_interpol(4.2, 1.5, 6.534, 3.6, 8.387**2)), 8.387]),
+            ("gDisc_and_sigmaSn", [1.5, 4.2, 6.534],
+             {"sigma2_disc": [1.5, 3.6], 'sigma2_Sn': [6.534, 8.387**2]},
              [np.sqrt(3.6),
               np.sqrt(y_interpol(4.2, 1.5, 6.534, 3.6, 8.387**2)), 8.387])
             ]


### PR DESCRIPTION
I've added a slightly different version of the `Disc_and_EB05` where the parameterisation doesn't use the EB05 for sigmaSn. Instead the sigmaSn is supplied by the user.