### PR TITLE
Write correct units on x-axis label

### DIFF
--- a/ompy/vector.py
+++ b/ompy/vector.py
@@ -155,7 +155,7 @@ class Vector(AbstractArray):
             kwargs.setdefault("fmt", "o")
             ax.errorbar(self.E, self.values, yerr=self.std, **kwargs)
         ax.set_yscale(scale)
-        ax.set_xlabel("Energy")
+        ax.set_xlabel(f"Energy [{self.units}]")
         return fig, ax
 
     def save(self, path: Union[str, Path],


### PR DESCRIPTION
The `Vector` class already knows what units the x-axis has through the `units` attribute.
There is no reason not to write it on the x-axis :p