### PR TITLE
Fix for setup issue on non-x86 platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ The simplest way to get the new repo is to rerun the installation instructions b
 #### Saving `Vector`´s in `MaMa` format
 The `MaMa` format has some limitation. Mainly the format will not be able to save the `std` attribute, meaning that error-bars will not be stored. The `MaMa` format is always in keV units, meaning that the `units` keyword in the `Vector.save` method is ignored.
 
+#### Compiling with `gcc` on macOS
+Short answer: Don't. Long answer: If you want to compile using `gcc` you are on your own. This is not a standard setup and will require careful configuration of the system. There is a recent update (PR #191) that will ensure that compilation will complete without any issues, however there may be linking issues at runtime. If you have issues, please consider using the standard `clang` compiler or use the docker image.
+
 ## General usage
 All the functions and classes in the package are available in the main module. You get everything by importing the package
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The simplest way to get the new repo is to rerun the installation instructions b
 The `MaMa` format has some limitation. Mainly the format will not be able to save the `std` attribute, meaning that error-bars will not be stored. The `MaMa` format is always in keV units, meaning that the `units` keyword in the `Vector.save` method is ignored.
 
 #### Compiling with `gcc` on macOS
-Short answer: Don't. Long answer: If you want to compile using `gcc` you are on your own. This is not a standard setup and will require careful configuration of the system. There is a recent update (PR #191) that will ensure that compilation will complete without any issues, however there may be linking issues at runtime. If you have issues, please consider using the standard `clang` compiler or use the docker image.
+Short answer: Don't. Please use `clang`.
 
 ## General usage
 All the functions and classes in the package are available in the main module. You get everything by importing the package

--- a/release_note.md
+++ b/release_note.md
@@ -11,6 +11,8 @@ Changed:
 - Fixed a bug where the `std` attribute of `Vector` was not saved to file.
 - Reimplemented PPF for normal distribution and truncated normal distribution in C++ for improved performance (about 300% faster than the SciPy implementation!).
 - Fixed a potential bug where `units` attribute is set erroniously when reading the discrete level density from file (`load_levels_discrete` and `load_levels_discrete_smooth`).
+- Fixed a bug that prevented compilation on ARM platforms.
+- Added a workaround for cases where `gcc` is used rather than `clang` on macOS. This setup will probably still fail on runtime unless the system is correctly configured. That is not our problem, solve it yourself. 
 
 Deprecated:
 - `shape` argument of Matrix for creation of a matrix filled with zeros. Use `ZerosMatrix` instead.

--- a/release_note.md
+++ b/release_note.md
@@ -12,7 +12,6 @@ Changed:
 - Reimplemented PPF for normal distribution and truncated normal distribution in C++ for improved performance (about 300% faster than the SciPy implementation!).
 - Fixed a potential bug where `units` attribute is set erroniously when reading the discrete level density from file (`load_levels_discrete` and `load_levels_discrete_smooth`).
 - Fixed a bug that prevented compilation on ARM platforms.
-- Added a workaround for cases where `gcc` is used rather than `clang` on macOS. This setup will probably still fail on runtime unless the system is correctly configured. That is not our problem, solve it yourself. 
 
 Deprecated:
 - `shape` argument of Matrix for creation of a matrix filled with zeros. Use `ZerosMatrix` instead.

--- a/setup.py
+++ b/setup.py
@@ -131,20 +131,27 @@ fname = "ompy/decomposition.c"  # otherwise it may not recompile
 if os.path.exists(fname):
     os.remove(fname)
 
-extra_compile_args = ["-O3", "-ffast-math", "-march=native"]
+# Check CPU architecture. If x86 apply x86 optimization
+extra_compile_args_cython = ["-O3", "-ffast-math", "-march=native"]
+extra_compile_args_cpp = ["-std=c++11", "-O3",
+                          "-funroll-loops", "-march=native"]
+if platform == "i386":
+    extra_compile_args_cpp = ["-mfpmath=sse"]
+
+
 extra_link_args = []
 if openmp and platform.system() == 'Darwin':
-    extra_compile_args.insert(-1, "-Xpreprocessor -fopenmp")
+    extra_compile_args_cython.insert(-1, "-Xpreprocessor -fopenmp")
     extra_link_args.insert(-1, "-lomp")
 elif openmp:
-    extra_compile_args.insert(-1, "-fopenmp")
+    extra_compile_args_cython.insert(-1, "-fopenmp")
     extra_link_args.insert(-1, "-fopenmp")
 
 ext_modules = [
         Extension("ompy.decomposition",
                   ["ompy/decomposition.pyx"],
                   # on MacOS the clang compiler pretends not to support OpenMP, but in fact it does so
-                  extra_compile_args=extra_compile_args,
+                  extra_compile_args=extra_compile_args_cython,
                   extra_link_args=extra_link_args,
                   include_dirs=[numpy.get_include()]
                   ),
@@ -155,9 +162,7 @@ ext_modules = [
 ext_modules_pybind11 = [
         Pybind11Extension("ompy.stats",
                           ["src/stats.cpp"],
-                          extra_compile_args=["-std=c++11", "-mfpmath=sse",
-                                              "-O3", "-funroll-loops",
-                                              "-march=native"])
+                          extra_compile_args=extra_compile_args_cpp)
 ]
 
 install_requires = [

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,13 @@ MICRO = 0
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 
+def check_if_clang_compiler():
+    """Check if the compiler is clang or gcc"""
+    std_err = subprocess.run("gcc", capture_output=True, text=True).stderr
+    if "clang" in std_err:
+        return true
+
+
 # Return the git revision as a string
 # See also ompy/version.py
 def git_version():
@@ -140,7 +147,7 @@ if platform == "i386":
 
 
 extra_link_args = []
-if openmp and platform.system() == 'Darwin':
+if openmp and platform.system() == 'Darwin' and check_if_clang_compiler():
     extra_compile_args_cython.insert(-1, "-Xpreprocessor -fopenmp")
     extra_link_args.insert(-1, "-lomp")
 elif openmp:

--- a/setup.py
+++ b/setup.py
@@ -26,17 +26,6 @@ MICRO = 0
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 
-def check_if_clang_compiler():
-    """Check if the compiler is clang or gcc"""
-
-    # Find the CC variable
-    cc = os.getenv("CC")
-    cc = 'gcc' if cc is None else cc  # Will be gcc if none.
-    std_err = subprocess.run(cc, capture_output=True, text=True).stderr
-    if "clang" in std_err:
-        return True
-
-
 # Return the git revision as a string
 # See also ompy/version.py
 def git_version():
@@ -146,7 +135,7 @@ extra_compile_args_cython = ["-O3", "-ffast-math"]
 extra_compile_args_cpp = ["-std=c++11", "-O3"]
 
 extra_link_args = []
-if openmp and platform.system() == 'Darwin' and check_if_clang_compiler():
+if openmp and platform.system() == 'Darwin':
     extra_compile_args_cython.insert(-1, "-Xpreprocessor -fopenmp")
     extra_link_args.insert(-1, "-lomp")
 elif openmp:
@@ -170,20 +159,6 @@ ext_modules_pybind11 = [
                           ["src/stats.cpp"],
                           extra_compile_args=extra_compile_args_cpp)
 ]
-
-# Superhacky solution to get pybind11 to play nicely with GCC...
-if platform.system() == 'Darwin' and not check_if_clang_compiler():
-    try:
-        idx = ext_modules_pybind11[0].extra_compile_args.index(
-            '-stdlib=libc++')
-        del ext_modules_pybind11[0].extra_compile_args[idx]
-    except ValueError:
-        pass
-    try:
-        idx = ext_modules_pybind11[0].extra_link_args.index('-stdlib=libc++')
-        del ext_modules_pybind11[0].extra_link_args[idx]
-    except ValueError:
-        pass
 
 install_requires = [
  "cython",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def check_if_clang_compiler():
     """Check if the compiler is clang or gcc"""
     std_err = subprocess.run("gcc", capture_output=True, text=True).stderr
     if "clang" in std_err:
-        return true
+        return True
 
 
 # Return the git revision as a string

--- a/setup.py
+++ b/setup.py
@@ -142,13 +142,8 @@ fname = "ompy/decomposition.c"  # otherwise it may not recompile
 if os.path.exists(fname):
     os.remove(fname)
 
-# Check CPU architecture. If x86 apply x86 optimization
-extra_compile_args_cython = ["-O3", "-ffast-math", "-march=native"]
-extra_compile_args_cpp = ["-std=c++11", "-O3",
-                          "-funroll-loops", "-march=native"]
-if platform == "i386":
-    extra_compile_args_cpp = ["-mfpmath=sse"]
-
+extra_compile_args_cython = ["-O3", "-ffast-math"]
+extra_compile_args_cpp = ["-std=c++11", "-O3"]
 
 extra_link_args = []
 if openmp and platform.system() == 'Darwin' and check_if_clang_compiler():

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ def check_if_clang_compiler():
     if "clang" in std_err:
         return True
 
+
 # Return the git revision as a string
 # See also ompy/version.py
 def git_version():
@@ -178,7 +179,8 @@ ext_modules_pybind11 = [
 # Superhacky solution to get pybind11 to play nicely with GCC...
 if platform.system() == 'Darwin' and not check_if_clang_compiler():
     try:
-        idx = ext_modules_pybind11[0].extra_compile_args.index('-stdlib=libc++')
+        idx = ext_modules_pybind11[0].extra_compile_args.index(
+            '-stdlib=libc++')
         del ext_modules_pybind11[0].extra_compile_args[idx]
     except ValueError:
         pass

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,10 @@ def check_if_clang_compiler():
     if "clang" in std_err:
         return True
 
+if check_if_clang_compiler():
+    print("I found clang")
+else:
+    print("I found GCC")
 
 # Return the git revision as a string
 # See also ompy/version.py


### PR DESCRIPTION
The setup.py script used a x86 spesific flags,`-mfpmath=sse`, that would break compilation on other architectures. This flag is now disabled for architectures other than x86. Fixes issue #190.

Marked as draft awaiting test on an actual M1 computer.