### PR TITLE
Fixed a bug in `ompy.library.log_interp1d`

### DIFF
--- a/ompy/library.py
+++ b/ompy/library.py
@@ -293,8 +293,9 @@ def interpolate_matrix_2D(matrix_in, E0_array_in, E1_array_in,
 
 def log_interp1d(xx, yy, **kwargs):
     """ Interpolate a 1-D function.logarithmically """
+    kwargs.setdefault('kind', 'linear')
     logy = np.log(yy)
-    lin_interp = interp1d(xx, logy, kind='linear', **kwargs)
+    lin_interp = interp1d(xx, logy, **kwargs)
     log_interp = lambda zz: np.exp(lin_interp(zz))  # noqa
     return log_interp
 


### PR DESCRIPTION
I've fixed a minor bug in `ompy.library.log_interp1d` which prevented the user to set the `kind` keyword arguments to `scipy.interpolate.interp1d`. The default value is now set to `kind='linear'` and can be changed by the user.

I'm also considering adding a `lin_interp1d` to `ompy.library`. Mainly since it could complement the `log_interp1d`.
```python
def lin_interp1d(xx, yy, **kwargs):
    """ Interpolate a 1-D function.logarithmically """
    kwargs.setdefault('kind', 'linear')
    lin_interp = interp1d(xx, yy, **kwargs)
    return lin_interp
```
Any objections?

One could also redo the two interpolation functions into a single function `interp1d(xx, yy, type='log/lin', **kwargs)` but that would require a little work to properly propagate the change to the entire package, and would not be backwards compatible if any users have used it explicitly. One could preserve the current function as a "legacy" solution with the 'new' as a wrapper:
```python
def interp1d(xx, yy, type='log', **kwargs):
    if type == 'lin':
        return lin_interp1d(xx, yy, **kwargs)
    if type == 'log':
        return log_interp1d(xx, yy, **kwargs)
    else:
        raise TypeError(f"Unsupported 'type' keyword: '{type}'")
```
and add a depreciation warning when the legacy versions are used.